### PR TITLE
fix: hang when getting p2p map(invoke full_tensor())

### DIFF
--- a/prototyping/distributed_tensor_transfer/launch.sh
+++ b/prototyping/distributed_tensor_transfer/launch.sh
@@ -10,18 +10,18 @@ rm -rf prototyping/distributed_tensor_transfer/dbs/* -rf
 mkdir -p prototyping/distributed_tensor_transfer/dbs
 
 echo "🚀 Starting Agent processes (ranks 0-7)..."
-pixi run torchrun --nproc_per_node=8 --master-port=29500 prototyping/distributed_tensor_transfer/agent.py > prototyping/distributed_tensor_transfer/logs/agent.log 2>&1 &
+pixi run torchrun --nproc_per_node=8 --master-port=39500 prototyping/distributed_tensor_transfer/agent.py > prototyping/distributed_tensor_transfer/logs/agent.log 2>&1 &
 
 # Wait for agents to be ready
 echo "⏳ Waiting for agents to initialize..."
 sleep 5
 
 echo "🔥 Starting Training workers (ranks 0-3)..."
-TRAINING_STRATEGY=${TRAINING_STRATEGY:-"hybrid_dp_mp"} pixi run torchrun --nproc_per_node=4 --master-port=29501 \
+TRAINING_STRATEGY=${TRAINING_STRATEGY:-"hybrid_dp_mp"} pixi run torchrun --nproc_per_node=4 --master-port=39501 \
     prototyping/distributed_tensor_transfer/train.py > prototyping/distributed_tensor_transfer/logs/train.log 2>&1 &
 
 echo "🔥 Starting Inference workers (ranks 0-3, connecting to agents 4-7)..."
-AGENT_RANK_OFFSET=4 INFERENCE_STRATEGY=${INFERENCE_STRATEGY:-"pure_mp"} pixi run torchrun --nproc_per_node=4 --master-port=29502 \
+AGENT_RANK_OFFSET=4 INFERENCE_STRATEGY=${INFERENCE_STRATEGY:-"hybrid_dp_mp"} pixi run torchrun --nproc_per_node=4 --master-port=39502 \
     prototyping/distributed_tensor_transfer/inference.py > prototyping/distributed_tensor_transfer/logs/inference.log 2>&1 &
 
 echo ""

--- a/src/etha/comm/p2p_map.py
+++ b/src/etha/comm/p2p_map.py
@@ -62,7 +62,7 @@ def get_p2p_map(
     reqs = []
     if rank in source_mesh_ranks:
         middle_tensor = torch.zeros(middle_tensor_shape, device=device)
-        dtensor_source = distribute_tensor(middle_tensor, source_mesh, source_placements, src_data_rank=None)
+        dtensor_source = distribute_tensor(middle_tensor, source_mesh, source_placements)
         local_shard = dtensor_source.to_local()
         logger.debug(f"[P2P Map rank={rank}] Local Source Shard: {local_shard}")
         # Create tensor with rank and coordinates encoded as single values

--- a/src/etha/tensor_bus/agent.py
+++ b/src/etha/tensor_bus/agent.py
@@ -239,26 +239,29 @@ class TensorBusAgent:
             # Rule: alphabetically smaller role is source first, larger is target
             send_first = local_name < remote_name
             if send_first:
-                local_mesh = DeviceMesh("cuda", local_mesh_tensor)
-                remote_mesh = DeviceMesh("cuda", remote_mesh_tensor)
+                sender_mesh = DeviceMesh("cuda", local_mesh_tensor)
+                receiver_mesh = DeviceMesh("cuda", remote_mesh_tensor)
+                sender_placements = local_placements
+                receiver_placements = remote_placements
             else:
-                local_mesh = DeviceMesh("cuda", remote_mesh_tensor)
-                remote_mesh = DeviceMesh("cuda", local_mesh_tensor)
-                local_placements, remote_placements = remote_placements, local_placements
+                sender_mesh = DeviceMesh("cuda", remote_mesh_tensor)
+                receiver_mesh = DeviceMesh("cuda", local_mesh_tensor)
+                sender_placements = remote_placements
+                receiver_placements = local_placements
             logger.info(f"Agent {self.rank}: Generating P2P map for pair '{pair_name}'")
 
             forward_map_send, reverse_map_send, source_num_slicers_send, target_num_slicers_send = get_p2p_map(
-                source_mesh=local_mesh,
-                source_placements=local_placements,
-                target_mesh=remote_mesh,
-                target_placements=remote_placements,
+                source_mesh=sender_mesh,
+                source_placements=sender_placements,
+                target_mesh=receiver_mesh,
+                target_placements=receiver_placements,
                 device="cuda",
             )
             forward_map_recv, reverse_map_recv, source_num_slicers_recv, target_num_slicers_recv = get_p2p_map(
-                source_mesh=remote_mesh,
-                source_placements=remote_placements,
-                target_mesh=local_mesh,
-                target_placements=local_placements,
+                source_mesh=receiver_mesh,
+                source_placements=receiver_placements,
+                target_mesh=sender_mesh,
+                target_placements=sender_placements,
                 device="cuda",
             )
             if send_first:

--- a/src/etha/tensor_bus/agent.py
+++ b/src/etha/tensor_bus/agent.py
@@ -229,64 +229,64 @@ class TensorBusAgent:
             local_mesh_tensor = torch.arange(
                 local_ranks[0], local_ranks[0] + torch.prod(torch.tensor(local_mesh_shape))
             ).view(local_mesh_shape)
-            local_mesh = DeviceMesh("cuda", local_mesh_tensor)
-            # Get remote mesh info (peer's mesh)
             remote_mesh_shape, remote_placements = remote_mesh_info[0]
             remote_mesh_tensor = torch.arange(
                 remote_ranks[0], remote_ranks[0] + torch.prod(torch.tensor(remote_mesh_shape))
             ).view(remote_mesh_shape)
-            remote_mesh = DeviceMesh("cuda", remote_mesh_tensor)
-            logger.info(f"Agent {self.rank}: Local mesh: {local_mesh.mesh} with placements: {local_placements}")
-            logger.info(f"Agent {self.rank}: Remote mesh: {remote_mesh.mesh} with placements: {remote_placements}")
+            logger.info(f"Agent {self.rank}: Local mesh: {local_mesh_tensor} with placements: {local_placements}")
+            logger.info(f"Agent {self.rank}: Remote mesh: {remote_mesh_tensor} with placements: {remote_placements}")
 
             # Rule: alphabetically smaller role is source first, larger is target
             send_first = local_name < remote_name
             if send_first:
-                logger.info(f"Agent {self.rank}: Generating P2P map for {local_name}->{remote_name}")
-                forward_map_send, reverse_map_send, source_num_slicers_send, target_num_slicers_send = get_p2p_map(
-                    source_mesh=local_mesh,
-                    source_placements=local_placements,
-                    target_mesh=remote_mesh,
-                    target_placements=remote_placements,
-                    device="cuda",
-                )
-                logger.info(f"Agent {self.rank}: Generating P2P map for {remote_name}->{local_name}")
-                forward_map_recv, reverse_map_recv, source_num_slicers_recv, target_num_slicers_recv = get_p2p_map(
-                    source_mesh=remote_mesh,
-                    source_placements=remote_placements,
-                    target_mesh=local_mesh,
-                    target_placements=local_placements,
-                    device="cuda",
-                )
+                local_mesh = DeviceMesh("cuda", local_mesh_tensor)
+                remote_mesh = DeviceMesh("cuda", remote_mesh_tensor)
             else:
-                logger.info(f"Agent {self.rank}: Generating P2P map for {remote_name}->{local_name}")
-                forward_map_recv, reverse_map_recv, source_num_slicers_recv, target_num_slicers_recv = get_p2p_map(
-                    source_mesh=remote_mesh,
-                    source_placements=remote_placements,
-                    target_mesh=local_mesh,
-                    target_placements=local_placements,
-                    device="cuda",
-                )
-                logger.info(f"Agent {self.rank}: Generating P2P map for {local_name}->{remote_name}")
-                forward_map_send, reverse_map_send, source_num_slicers_send, target_num_slicers_send = get_p2p_map(
-                    source_mesh=local_mesh,
-                    source_placements=local_placements,
-                    target_mesh=remote_mesh,
-                    target_placements=remote_placements,
-                    device="cuda",
-                )
-            p2p_map_send = {
-                "forward_map": forward_map_send,
-                "reverse_map": reverse_map_send,
-                "source_num_slicers": source_num_slicers_send,
-                "target_num_slicers": target_num_slicers_send,
-            }
-            p2p_map_recv = {
-                "forward_map": forward_map_recv,
-                "reverse_map": reverse_map_recv,
-                "source_num_slicers": source_num_slicers_recv,
-                "target_num_slicers": target_num_slicers_recv,
-            }
+                local_mesh = DeviceMesh("cuda", remote_mesh_tensor)
+                remote_mesh = DeviceMesh("cuda", local_mesh_tensor)
+            logger.info(f"Agent {self.rank}: Generating P2P map for pair '{pair_name}'")
+
+            forward_map_send, reverse_map_send, source_num_slicers_send, target_num_slicers_send = get_p2p_map(
+                source_mesh=local_mesh,
+                source_placements=local_placements,
+                target_mesh=remote_mesh,
+                target_placements=remote_placements,
+                device="cuda",
+            )
+            forward_map_recv, reverse_map_recv, source_num_slicers_recv, target_num_slicers_recv = get_p2p_map(
+                source_mesh=remote_mesh,
+                source_placements=remote_placements,
+                target_mesh=local_mesh,
+                target_placements=local_placements,
+                device="cuda",
+            )
+            if send_first:
+                p2p_map_send = {
+                    "forward_map": forward_map_send,
+                    "reverse_map": reverse_map_send,
+                    "source_num_slicers": source_num_slicers_send,
+                    "target_num_slicers": target_num_slicers_send,
+                }
+                p2p_map_recv = {
+                    "forward_map": forward_map_recv,
+                    "reverse_map": reverse_map_recv,
+                    "source_num_slicers": source_num_slicers_recv,
+                    "target_num_slicers": target_num_slicers_recv,
+                }
+            else:
+                p2p_map_send = {
+                    "forward_map": forward_map_recv,
+                    "reverse_map": reverse_map_recv,
+                    "source_num_slicers": source_num_slicers_recv,
+                    "target_num_slicers": target_num_slicers_recv,
+                }
+                p2p_map_recv = {
+                    "forward_map": forward_map_send,
+                    "reverse_map": reverse_map_send,
+                    "source_num_slicers": source_num_slicers_send,
+                    "target_num_slicers": target_num_slicers_send,
+                }
+
             logger.info(f"Agent {self.rank}: Generated P2P map for pair '{pair_name}'")
             logger.info(
                 f"Agent {self.rank}: Forward map: {p2p_map_send['forward_map']} source_num_slicers: {p2p_map_send['source_num_slicers']} target_num_slicers: {p2p_map_send['target_num_slicers']}"

--- a/src/etha/tensor_bus/agent.py
+++ b/src/etha/tensor_bus/agent.py
@@ -244,6 +244,7 @@ class TensorBusAgent:
             else:
                 local_mesh = DeviceMesh("cuda", remote_mesh_tensor)
                 remote_mesh = DeviceMesh("cuda", local_mesh_tensor)
+                local_placements, remote_placements = remote_placements, local_placements
             logger.info(f"Agent {self.rank}: Generating P2P map for pair '{pair_name}'")
 
             forward_map_send, reverse_map_send, source_num_slicers_send, target_num_slicers_send = get_p2p_map(

--- a/tests/test_communication_symmetric_mesh.py
+++ b/tests/test_communication_symmetric_mesh.py
@@ -7,8 +7,7 @@ import logging
 import torch
 import pytest
 import torch.distributed as dist
-from torch.distributed._tensor import Shard, Replicate, DeviceMesh, distribute_tensor
-from torch.distributed.tensor.placement_types import _StridedShard
+from torch.distributed._tensor import Shard, DeviceMesh, distribute_tensor
 
 from etha.comm import (
     get_p2p_map,
@@ -31,14 +30,19 @@ def run_test_communication(
     source_world_size = math.prod(source_mesh_shape)
     target_world_size = math.prod(target_mesh_shape)
 
-    source_mesh = DeviceMesh(device, torch.arange(source_world_size).view(source_mesh_shape))
-    target_mesh = DeviceMesh(
-        device,
-        torch.arange(source_world_size, source_world_size + target_world_size).view(target_mesh_shape),
-    )
+    if rank < source_world_size:
+        source_mesh = DeviceMesh(device, torch.arange(source_world_size).view(source_mesh_shape))
+        target_mesh = DeviceMesh(
+            device, torch.arange(source_world_size, source_world_size + target_world_size).view(target_mesh_shape)
+        )
+    else:
+        target_mesh = DeviceMesh(device, torch.arange(source_world_size).view(source_mesh_shape))
+        source_mesh = DeviceMesh(
+            device, torch.arange(source_world_size, source_world_size + target_world_size).view(target_mesh_shape)
+        )
 
-    source_specs = [Replicate(), Replicate(), Shard(0), Shard(1)]
-    target_specs = [Replicate(), _StridedShard(1, split_factor=2), Replicate(), Shard(1)]
+    source_specs = [Shard(1)]
+    target_specs = [Shard(1)]
     # Dummy tensor shape
     torch.manual_seed(0)
     shape = (64, 64)
@@ -46,29 +50,51 @@ def run_test_communication(
     target_origin_tensor = torch.randn(shape, device=device)
     is_in_source = rank < source_world_size
 
-    source_dist_tensor = distribute_tensor(source_origin_tensor, source_mesh, source_specs)
-    source_local_tensor = source_dist_tensor.to_local()
+    source_dist_tensor = None
+    source_local_tensor = None
+    if is_in_source:
+        source_dist_tensor = distribute_tensor(source_origin_tensor, source_mesh, source_specs)
+        source_local_tensor = source_dist_tensor.to_local()
 
-    target_dist_tensor = distribute_tensor(target_origin_tensor, target_mesh, target_specs)
-    target_local_tensor = target_dist_tensor.to_local()
+    target_dist_tensor = None
+    target_local_tensor = None
+    if not is_in_source:
+        target_dist_tensor = distribute_tensor(target_origin_tensor, source_mesh, target_specs)
+        target_local_tensor = target_dist_tensor.to_local()
 
     logger.debug(f"[rank={rank}] Source mesh: {source_mesh.mesh}")
     logger.debug(f"[rank={rank}] Target mesh: {target_mesh.mesh}")
     # Test P2P Map Method
-    forward_map, reverse_map, source_num_slicers, target_num_slicers = get_p2p_map(
-        source_mesh,
-        source_specs,
-        target_mesh,
-        target_specs,
-        device,
-    )
-    forward_map_2, reverse_map_2, source_num_slicers_2, target_num_slicers_2 = get_p2p_map(
-        target_mesh,
-        target_specs,
-        source_mesh,
-        source_specs,
-        device,
-    )
+    if is_in_source:
+        forward_map, reverse_map, source_num_slicers, target_num_slicers = get_p2p_map(
+            source_mesh,
+            source_specs,
+            target_mesh,
+            target_specs,
+            device,
+        )
+        forward_map_2, reverse_map_2, source_num_slicers_2, target_num_slicers_2 = get_p2p_map(
+            target_mesh,
+            target_specs,
+            source_mesh,
+            source_specs,
+            device,
+        )
+    else:
+        forward_map, reverse_map, source_num_slicers, target_num_slicers = get_p2p_map(
+            target_mesh,
+            target_specs,
+            source_mesh,
+            source_specs,
+            device,
+        )
+        forward_map_2, reverse_map_2, source_num_slicers_2, target_num_slicers_2 = get_p2p_map(
+            source_mesh,
+            source_specs,
+            target_mesh,
+            target_specs,
+            device,
+        )
     if rank == 0:
         logger.info(f"Forward Map: {forward_map}")
         logger.info(f"Reverse Map: {reverse_map}")
@@ -89,8 +115,8 @@ def run_test_communication(
 
     # Test Gather-Broadcast Method
     gather_broadcast_result = gather_broadcast_communicate(
-        target_mesh,
-        target_specs,
+        source_mesh,
+        source_specs,
         source_dist_tensor,
         target_origin_tensor,
         source_world_size,
@@ -113,22 +139,7 @@ def run_test_communication(
 @pytest.mark.parametrize(
     "source_mesh_shape, target_mesh_shape",
     [
-        # Same mesh shapes (identity)
-        ((2, 2, 2, 2), (2, 2, 2, 2)),
-        # Last dimension scaling (common case)
-        ((2, 2, 2, 2), (2, 2, 2, 4)),  # Scale up last dim
-        ((2, 2, 2, 4), (2, 2, 2, 2)),  # Scale down last dim
-        # Second-to-last dimension scaling
-        ((2, 2, 2, 2), (2, 2, 4, 2)),
-        ((2, 2, 4, 2), (2, 2, 2, 2)),
-        # Multiple dimension scaling
-        ((2, 2, 2, 2), (2, 2, 4, 4)),
-        ((2, 2, 4, 4), (2, 2, 2, 2)),
-        # First dimension scaling (edge case)
-        ((2, 2, 2, 2), (4, 2, 2, 2)),
-        # Complex mixed scaling
-        ((2, 2, 2, 4), (2, 4, 4, 2)),
-        ((2, 4, 2, 2), (2, 2, 4, 4)),
+        ((4,), (4,)),
     ],
 )
 def test_communication_cpu(source_mesh_shape: tuple, target_mesh_shape: tuple):


### PR DESCRIPTION
## What you did
创建device mesh需要所有rank同时创建，同时创建同一个device mesh。

## Test Results
<img width="1262" height="618" alt="image" src="https://github.com/user-attachments/assets/877fa0b4-4db6-4c0d-8c61-b56625d0d2bd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated peer-to-peer map generation with unified tensor-based mesh handling and simplified logging.

* **Tests**
  * Added a CPU-focused distributed communication test suite for symmetric meshes with end-to-end P2P and gather-broadcast validations.

* **Improvements**
  * Communication now always distributes source/target tensors to local slices and logs mesh descriptors per rank.

* **Chores**
  * Updated default inference strategy and shifted default communication ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->