### PR TITLE
fix: use local group instead of global group for barrier and all_gather

### DIFF
--- a/bench/benchmark.py
+++ b/bench/benchmark.py
@@ -392,6 +392,7 @@ def main():
             source_specs,
             current_target_mesh,
             target_specs,
+            dist.group.WORLD,
             device,
         )
         map_time = (time.perf_counter() - start_time) / profile_iter

--- a/prototyping/distributed_tensor_transfer/common.py
+++ b/prototyping/distributed_tensor_transfer/common.py
@@ -26,7 +26,7 @@ PURE_MP_PLACEMENTS = ("Shard(dim=1)",)  # Shard model parameters on column dimen
 
 # TCPStore configuration
 TCPSTORE_HOST = "localhost"
-TCPSTORE_PORT = 29500
+TCPSTORE_PORT = 39505
 
 # Base path for LMDB storage
 LMDB_ROOT = f"{os.environ['PIXI_PROJECT_ROOT']}/prototyping/distributed_tensor_transfer/dbs"

--- a/prototyping/distributed_tensor_transfer/inference.py
+++ b/prototyping/distributed_tensor_transfer/inference.py
@@ -80,8 +80,6 @@ class DistributedInferenceEngine:
 
 def main():
     # Bootstrap TensorBusClient with rank offset for inference workers
-    os.environ["AGENT_RANK_OFFSET"] = "4"
-
     client, info = bootstrap_client(path_naming_fn=get_queue_state_paths)
 
     logger.info(f"\n{'=' * 60}")

--- a/src/etha/comm/p2p_map.py
+++ b/src/etha/comm/p2p_map.py
@@ -20,6 +20,7 @@ def get_p2p_map(
     source_placements: tuple[Placement, ...],
     target_mesh: DeviceMesh,
     target_placements: tuple[Placement, ...],
+    group: dist.ProcessGroup,
     device: str = "cpu",
 ) -> tuple[dict[int, dict[tuple, list[int]]], dict[int, dict[tuple, list[tuple[int, tuple]]]], list[int], list[int]]:
     """Get P2P communication map for tensor redistribution."""
@@ -156,8 +157,8 @@ def get_p2p_map(
     all_forward_maps = [None] * (len(source_mesh_ranks) + len(target_mesh_ranks))
     all_reverse_maps = [None] * (len(source_mesh_ranks) + len(target_mesh_ranks))
 
-    dist.all_gather_object(all_forward_maps, forward_map_regular, group=None)
-    dist.all_gather_object(all_reverse_maps, reverse_map_regular, group=None)
+    dist.all_gather_object(all_forward_maps, forward_map_regular, group=group)
+    dist.all_gather_object(all_reverse_maps, reverse_map_regular, group=group)
 
     merged_forward_map = defaultdict(make_nested_defaultdict)
     merged_reverse_map = defaultdict(make_nested_defaultdict)

--- a/src/etha/tensor_bus/agent.py
+++ b/src/etha/tensor_bus/agent.py
@@ -212,6 +212,9 @@ class TensorBusAgent:
                 break
 
         logger.info(f"Agent {self.rank}: Remote peer '{remote_name}' complete: {remote_ranks}")
+        logger.debug(f"Agent {self.rank}: Creating pair group with ranks: {local_ranks + remote_ranks}")
+        pair_group = dist.new_group(ranks=(local_ranks + remote_ranks))
+        logger.debug(f"Agent {self.rank}: Pair group created: {pair_group}")
 
         # Step 6: Collect device mesh and placement info from all ranks
         local_mesh_info = self._collect_mesh_placement_info(pair_name, local_ranks)
@@ -259,6 +262,7 @@ class TensorBusAgent:
                 source_placements=sender_placements,
                 target_mesh=receiver_mesh,
                 target_placements=receiver_placements,
+                group=pair_group,
                 device="cuda",
             )
             forward_map_recv, reverse_map_recv, source_num_slicers_recv, target_num_slicers_recv = get_p2p_map(
@@ -266,6 +270,7 @@ class TensorBusAgent:
                 source_placements=receiver_placements,
                 target_mesh=sender_mesh,
                 target_placements=sender_placements,
+                group=pair_group,
                 device="cuda",
             )
             if send_first:
@@ -311,6 +316,7 @@ class TensorBusAgent:
             remote_ranks=remote_ranks,
             pair_size=expected_local + expected_remote,
             local_group=dist.new_group(local_ranks),
+            pair_group=pair_group,
             status="matched",
             p2p_map_send=p2p_map_send,
             p2p_map_recv=p2p_map_recv,
@@ -415,7 +421,7 @@ class TensorBusAgent:
                 logger.info(f"Agent {self.rank}: Transfered tensor_name: '{tensor_name}'")
 
         # Cleanup
-        dist.barrier()
+        dist.barrier(group=pair_state.pair_group)
         self.store.set(transfer_ready_key, "0")
         self.store.set(transfer_singal_key, "0")
         logger.info(f"Agent {self.rank}: Transfer completed for pair '{pair_name}'")

--- a/src/etha/tensor_bus/pair_state.py
+++ b/src/etha/tensor_bus/pair_state.py
@@ -15,6 +15,7 @@ class PairState(msgspec.Struct):
     remote_ranks: list[int]  # Ranks for remote peer (e.g., [8, 9, ..., 23])
     pair_size: int  # Total number of ranks in the pair
     local_group: dist.ProcessGroup  # Local process group
+    pair_group: dist.ProcessGroup  # Pair process group
     status: str  # "matched"
     tensors: dict[str, torch.Tensor] = {}  # tensor_name -> tensor mapping
     p2p_map_send: dict | None = None  # P2P transfer map for sending optimized communication

--- a/tests/test_communication_cpu.py
+++ b/tests/test_communication_cpu.py
@@ -60,6 +60,7 @@ def run_test_communication(
         source_specs,
         target_mesh,
         target_specs,
+        dist.group.WORLD,
         device,
     )
     forward_map_2, reverse_map_2, source_num_slicers_2, target_num_slicers_2 = get_p2p_map(
@@ -67,6 +68,7 @@ def run_test_communication(
         target_specs,
         source_mesh,
         source_specs,
+        dist.group.WORLD,
         device,
     )
     if rank == 0:

--- a/tests/test_communication_symmetric_mesh.py
+++ b/tests/test_communication_symmetric_mesh.py
@@ -71,6 +71,7 @@ def run_test_communication(
             source_specs,
             target_mesh,
             target_specs,
+            dist.group.WORLD,
             device,
         )
         forward_map_2, reverse_map_2, source_num_slicers_2, target_num_slicers_2 = get_p2p_map(
@@ -78,6 +79,7 @@ def run_test_communication(
             target_specs,
             source_mesh,
             source_specs,
+            dist.group.WORLD,
             device,
         )
     else:
@@ -86,6 +88,7 @@ def run_test_communication(
             target_specs,
             source_mesh,
             source_specs,
+            dist.group.WORLD,
             device,
         )
         forward_map_2, reverse_map_2, source_num_slicers_2, target_num_slicers_2 = get_p2p_map(
@@ -93,6 +96,7 @@ def run_test_communication(
             source_specs,
             target_mesh,
             target_specs,
+            dist.group.WORLD,
             device,
         )
     if rank == 0:


### PR DESCRIPTION
## Test results
<img width="3776" height="1200" alt="image" src="https://github.com/user-attachments/assets/719c471d-0fcf-40cf-b738-4f293e9db24c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Updated network communication port for distributed tensor transfers.

* **Bug Fixes / Improvements**
  * P2P mapping and gather operations now respect the global process grouping, improving multi-process mapping and transfer correctness.
  * Enhanced synchronization by coordinating transfers across combined local+remote process groups, increasing reliability.
  * Removed automatic rank-offset override in inference startup to allow correct rank assignment and more predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->