### PR TITLE
feat: bucketize communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ dev/
 
 dbs
 logs
+
+trace_processor

--- a/bench/benchmark.py
+++ b/bench/benchmark.py
@@ -15,15 +15,18 @@ from torch.distributed._tensor import Shard, Replicate, DeviceMesh, distribute_t
 from torch.distributed.tensor.placement_types import _StridedShard
 
 from etha.comm import (
+    chunk_comm,
+    bucket_comm,
     get_m2m_map,
-    m2m_communicate,
     map_to_chunk_ops,
-    gather_broadcast_communicate,
+    chunk_to_bucket_ops,
+    gather_broadcast_comm,
 )
 
 # Hardware bandwidth parameters (GB/s)
 RDMA_SEND_BANDWIDTH_GB_S = 50.0
 NVLINK_Single_BANDWIDTH_GB_S = 450.0
+BUCKET_SIZE_BYTES = 256 * 1024 * 1024
 
 
 def calculate_transfer_bytes(
@@ -110,6 +113,7 @@ def benchmark_single_shape(
     target_local_tensors: list,  # List of target local tensors
     shape: tuple,
     chunks: list,  # All chunks from all tensors (extended)
+    buckets: list,
     current_source_mesh: DeviceMesh,
     current_target_mesh: DeviceMesh,
     source_specs: list,  # noqa
@@ -148,18 +152,17 @@ def benchmark_single_shape(
     # M2M method warmup
     dist.barrier()
     for _ in range(warmup_iter):
-        m2m_communicate(chunks=chunks)
+        chunk_comm(chunks=chunks)
     if device == "cuda":
         torch.cuda.synchronize()
     dist.barrier()
 
     # M2M method with profiling if enabled
     if should_profile:
-        # Setup profiling for M2M
         m2m_profiling_spec = ProfilingSpec(
             enable_profiling=True,
             dump_folder=UPath(profiling_config["dump_folder"]),
-            save_traces_folder=UPath(f"traces/{mesh_info}/shape_{shape}/rank_{rank}/m2m_comm"),
+            save_traces_folder=UPath(f"traces/{mesh_info}/shape_{shape[0]}/rank_{rank}/m2m_comm"),
             profile_freq=profiling_config["profile_freq"],
             warmup_steps=profiling_config["warmup_steps"],
             active_steps=profiling_config["active_steps"],
@@ -174,16 +177,12 @@ def benchmark_single_shape(
                         torch.cuda.synchronize()
                     dist.barrier()
                     profiler.step()
-                    m2m_communicate(chunks=chunks)
+                    for _ in range(10):
+                        chunk_comm(chunks=chunks)
 
                     # Memory snapshot if requested
-                    if (
-                        profiling_config.get("enable_memory_snapshot", False)
-                        and step >= m2m_profiling_spec.warmup_steps
-                    ):
-                        snapshot_dir = (
-                            f"{profiling_config['dump_folder']}/memory_snapshots/{mesh_info}/shape_{shape}/rank_{rank}"
-                        )
+                    if m2m_profiling_spec.enable_memory_snapshot and step == m2m_profiling_spec.warmup_steps + 1:
+                        snapshot_dir = f"{m2m_profiling_spec.dump_folder}/memory_snapshots/{mesh_info}/shape_{shape[0]}/rank_{rank}"
                         dump_memory_snapshot(snapshot_dir, step, rank)
             else:
                 pass
@@ -191,7 +190,7 @@ def benchmark_single_shape(
         # Time measurement after profiling
         start_time = time.perf_counter()
         for _ in range(profile_iter):
-            m2m_communicate(chunks=chunks)
+            chunk_comm(chunks=chunks)
         if device == "cuda":
             torch.cuda.synchronize()
         dist.barrier()
@@ -200,11 +199,60 @@ def benchmark_single_shape(
         # Regular M2M benchmark without profiling
         start_time = time.perf_counter()
         for _ in range(profile_iter):
-            m2m_communicate(chunks=chunks)
+            chunk_comm(chunks=chunks)
         if device == "cuda":
             torch.cuda.synchronize()
         dist.barrier()
         m2m_time = (time.perf_counter() - start_time) / profile_iter
+
+    dist.barrier()
+    for _ in range(warmup_iter):
+        bucket_comm(buckets=buckets)
+    if device == "cuda":
+        torch.cuda.synchronize()
+    dist.barrier()
+
+    if should_profile:
+        bucket_profiling_spec = ProfilingSpec(
+            enable_profiling=True,
+            dump_folder=UPath(profiling_config["dump_folder"]),
+            save_traces_folder=UPath(f"traces/{mesh_info}/shape_{shape[0]}/rank_{rank}/bucket_comm"),
+            profile_freq=profiling_config["profile_freq"],
+            warmup_steps=profiling_config["warmup_steps"],
+            active_steps=profiling_config["active_steps"],
+            enable_memory_snapshot=profiling_config["enable_memory_snapshot"],
+        )
+
+        with maybe_enable_profiling(bucket_profiling_spec, global_step=0) as profiler:
+            if profiler is not None:
+                for step in range(bucket_profiling_spec.profile_freq):
+                    if device == "cuda":
+                        torch.cuda.synchronize()
+                    dist.barrier()
+                    profiler.step()
+                    for _ in range(10):
+                        bucket_comm(buckets=buckets)
+                    if bucket_profiling_spec.enable_memory_snapshot and step == bucket_profiling_spec.warmup_steps + 1:
+                        snapshot_dir = f"{bucket_profiling_spec.dump_folder}/memory_snapshots/{mesh_info}/shape_{shape[0]}/rank_{rank}"
+                        dump_memory_snapshot(snapshot_dir, step + 2000, rank)
+            else:
+                pass
+
+        start_time = time.perf_counter()
+        for _ in range(profile_iter):
+            bucket_comm(buckets=buckets)
+        if device == "cuda":
+            torch.cuda.synchronize()
+        dist.barrier()
+        bucket_time = (time.perf_counter() - start_time) / profile_iter
+    else:
+        start_time = time.perf_counter()
+        for _ in range(profile_iter):
+            bucket_comm(buckets=buckets)
+        if device == "cuda":
+            torch.cuda.synchronize()
+        dist.barrier()
+        bucket_time = (time.perf_counter() - start_time) / profile_iter
 
     # Gather-Broadcast method warmup (only test first tensor as reference)
     dist.barrier()
@@ -212,7 +260,7 @@ def benchmark_single_shape(
     for _ in range(warmup_iter):
         if source_dist_tensors:
             # Source ranks pass their distributed tensor
-            bc_result = gather_broadcast_communicate(
+            bc_result = gather_broadcast_comm(
                 current_target_mesh,
                 target_specs,
                 source_dist_tensors[0],  # Use first tensor as reference
@@ -221,7 +269,7 @@ def benchmark_single_shape(
             )
         else:
             # Target ranks still need to participate in the collective
-            bc_result = gather_broadcast_communicate(
+            bc_result = gather_broadcast_comm(
                 current_target_mesh,
                 target_specs,
                 None,  # No source tensor for target ranks
@@ -249,7 +297,7 @@ def benchmark_single_shape(
         gb_profiling_spec = ProfilingSpec(
             enable_profiling=True,
             dump_folder=UPath(profiling_config["dump_folder"]),
-            save_traces_folder=UPath(f"traces/{mesh_info}/shape_{shape}/rank_{rank}/gather_broadcast_comm"),
+            save_traces_folder=UPath(f"traces/{mesh_info}/shape_{shape[0]}/rank_{rank}/gather_broadcast_comm"),
             profile_freq=profiling_config["profile_freq"],
             warmup_steps=profiling_config["warmup_steps"],
             active_steps=profiling_config["active_steps"],
@@ -261,27 +309,28 @@ def benchmark_single_shape(
                 # Profiled iterations
                 for step in range(gb_profiling_spec.profile_freq):
                     profiler.step()
-                    if source_dist_tensors:
-                        gather_broadcast_communicate(
-                            current_target_mesh,
-                            target_specs,
-                            source_dist_tensors[0],
-                            origin_tensors[0],
-                            source_world_size,
-                        )
-                    else:
-                        gather_broadcast_communicate(
-                            current_target_mesh,
-                            target_specs,
-                            None,
-                            origin_tensors[0],
-                            source_world_size,
-                        )
+                    for _ in range(10):
+                        if source_dist_tensors:
+                            gather_broadcast_comm(
+                                current_target_mesh,
+                                target_specs,
+                                source_dist_tensors[0],
+                                origin_tensors[0],
+                                source_world_size,
+                            )
+                        else:
+                            gather_broadcast_comm(
+                                current_target_mesh,
+                                target_specs,
+                                None,
+                                origin_tensors[0],
+                                source_world_size,
+                            )
 
                     # Additional memory snapshot if requested
-                    if profiling_config.get("enable_memory_snapshot", False) and step >= gb_profiling_spec.warmup_steps:
+                    if gb_profiling_spec.enable_memory_snapshot and step == gb_profiling_spec.warmup_steps + 1:
                         snapshot_dir = (
-                            f"{profiling_config['dump_folder']}/memory_snapshots/{mesh_info}/shape_{shape}/rank_{rank}"
+                            f"{gb_profiling_spec.dump_folder}/memory_snapshots/{mesh_info}/shape_{shape[0]}/rank_{rank}"
                         )
                         dump_memory_snapshot(snapshot_dir, step + 1000, rank)  # +1000 to distinguish from M2M
             else:
@@ -291,7 +340,7 @@ def benchmark_single_shape(
         start_time = time.perf_counter()
         for _ in range(profile_iter):
             if source_dist_tensors:
-                gather_broadcast_communicate(
+                gather_broadcast_comm(
                     current_target_mesh,
                     target_specs,
                     source_dist_tensors[0],
@@ -299,7 +348,7 @@ def benchmark_single_shape(
                     source_world_size,
                 )
             else:
-                gather_broadcast_communicate(
+                gather_broadcast_comm(
                     current_target_mesh,
                     target_specs,
                     None,
@@ -315,7 +364,7 @@ def benchmark_single_shape(
         start_time = time.perf_counter()
         for _ in range(profile_iter):
             if source_dist_tensors:
-                gather_broadcast_communicate(
+                gather_broadcast_comm(
                     current_target_mesh,
                     target_specs,
                     source_dist_tensors[0],
@@ -323,7 +372,7 @@ def benchmark_single_shape(
                     source_world_size,
                 )
             else:
-                gather_broadcast_communicate(
+                gather_broadcast_comm(
                     current_target_mesh,
                     target_specs,
                     None,
@@ -352,6 +401,7 @@ def benchmark_single_shape(
         # Effective throughput: how fast we complete the redistribution task
         # M2M: tests all tensors in batch
         m2m_effective_throughput = ideal_transfer_gb / m2m_time
+        bucket_effective_throughput = ideal_transfer_gb / bucket_time
 
         # Baseline: only tests 1 tensor, so divide by num_tensors
         single_tensor_ideal_transfer_gb = ideal_transfer_gb / num_tensors
@@ -361,6 +411,7 @@ def benchmark_single_shape(
         print(f"    Ideal M2M transfer (target needs): {ideal_transfer_bytes / (1024**2):.2f} MB")
         print(f"    Ideal bandwidth (RDMA+NVLink): {ideal_bw:.2f} GB/s")
         print(f"    M2M batch effective throughput ({num_tensors} tensors): {m2m_effective_throughput:.2f} GB/s")
+        print(f"    Bucket batch effective throughput ({num_tensors} tensors): {bucket_effective_throughput:.2f} GB/s")
         print(f"    Baseline effective throughput (1 tensor): {baseline_effective_throughput:.2f} GB/s")
 
         return {
@@ -370,10 +421,25 @@ def benchmark_single_shape(
             "ideal_transfer_mb": ideal_transfer_bytes / (1024**2),
             "ideal_bandwidth_gb_s": ideal_bw,
             "m2m_effective_throughput_gb_s": m2m_effective_throughput,
+            "bucket_effective_throughput_gb_s": bucket_effective_throughput,
             "baseline_effective_throughput_gb_s": baseline_effective_throughput,
         }
 
     return None
+
+
+def _placements_to_str(placements: list) -> str:
+    parts = []
+    for placement in placements:
+        if isinstance(placement, Replicate):
+            parts.append("Replicate")
+        elif isinstance(placement, Shard):
+            parts.append(f"Shard({placement.dim})")
+        elif isinstance(placement, _StridedShard):
+            parts.append(f"StridedShard({placement.dim}, split={placement.split_factor})")
+        else:
+            parts.append(str(placement))
+    return "[" + ", ".join(parts) + "]"
 
 
 def generate_result_plot(
@@ -381,6 +447,9 @@ def generate_result_plot(
     source_mesh_shape: tuple,
     target_mesh_shape: tuple,
     mesh_idx: int,
+    num_tensors_per_batch: int,
+    source_specs: list,
+    target_specs: list,
 ):
     """Generate and save throughput comparison plot."""
     df = pd.DataFrame(results)
@@ -392,6 +461,7 @@ def generate_result_plot(
     plot_configs = [
         ("ideal_bandwidth_gb_s", "Ideal (RDMA+NVLink)", "--", "green", None),
         ("m2m_effective_throughput_gb_s", "M2M Effective", "o", "blue", 8),
+        ("bucket_effective_throughput_gb_s", "Bucket Effective", "s", "purple", 7),
         ("baseline_effective_throughput_gb_s", "Gather-Broadcast", "X", "orange", 8),
     ]
 
@@ -412,8 +482,11 @@ def generate_result_plot(
             )
 
     ax.set_title(
-        f"Batch Transfer Throughput (5 Tensors)\nMesh: {source_mesh_shape} → {target_mesh_shape}",
-        fontsize=14,
+        f"Batch Transfer Throughput ({num_tensors_per_batch} tensors)\n"
+        f"Mesh: {source_mesh_shape} → {target_mesh_shape}\n"
+        f"source_specs={_placements_to_str(source_specs)}\n"
+        f"target_specs={_placements_to_str(target_specs)}",
+        fontsize=11,
         weight="bold",
     )
     ax.set_xlabel("Total Batch Size (MB)", fontsize=11)
@@ -439,7 +512,7 @@ def main():
     # PROFILING CONFIGURATION (modify here)
     # ========================================
     ENABLE_PROFILING = False  # Set to True to enable profiling
-    PROFILE_SHAPES = [(4096, 4096), (8192, 8192), (16384, 16384)]  # Shapes to profile
+    PROFILE_SHAPES = [(8192, 8192)]  # Shapes to profile
     PROFILE_WARMUP = 2  # Warmup steps for profiling
     PROFILE_ACTIVE = 3  # Active profiling steps
     PROFILE_FREQ = 5  # Total frequency (warmup + active + wait)
@@ -488,8 +561,8 @@ def main():
                     print(f"Warning: Failed to enable memory recording: {e}")
 
     # BENCHMARKING PARAMETERS
-    warmup_iter = 5
-    profile_iter = 25
+    warmup_iter = 3
+    profile_iter = 20
     gpus_per_node = int(os.environ.get("LOCAL_WORLD_SIZE", 8))  # Default to 8 GPUs per node
 
     # Reduced shape list: each shape tests 5 tensors in batch
@@ -505,7 +578,7 @@ def main():
         (24576, 24576),
     ]
 
-    num_tensors_per_batch = 10  # Number of tensors to send in each batch
+    num_tensors_per_batch = 25  # Number of tensors to send in each batch
 
     # Mesh combinations: source_mesh_shape -> target_mesh_shape (total 16 devices)
     # Each dimension must be power of 2: 1, 2, 4, 8
@@ -622,12 +695,21 @@ def main():
                 )
                 all_chunks.extend(chunks)
 
+            all_buckets = chunk_to_bucket_ops(
+                chunks=all_chunks,
+                bucket_size=BUCKET_SIZE_BYTES,
+            )
+
             ir_gen_time = (time.perf_counter() - start_time) / profile_iter
             if rank == 0:
                 print(f"    IR generation time: {ir_gen_time:.6f}s")
                 print(
                     f"    Generated {len(all_chunks)} chunks total ({len(all_chunks) // num_tensors_per_batch} per tensor)"
                 )
+                print(
+                    f"    Generated {len(all_buckets)} buckets total ({len(all_buckets) // num_tensors_per_batch} per tensor)"
+                )
+                print(f"    m2m map: {m2m_map}")
 
             # Create mesh info string for output directory organization
             src = "_".join(map(str, source_mesh_shape))
@@ -640,6 +722,7 @@ def main():
                 target_local_tensors,
                 shape,
                 all_chunks,
+                all_buckets,
                 current_source_mesh,
                 current_target_mesh,
                 source_specs,
@@ -659,13 +742,21 @@ def main():
                 current_results.append(result)
 
             # Clean up tensors after each shape benchmark
-            del origin_tensors, source_dist_tensors, target_local_tensors, all_chunks
+            del origin_tensors, source_dist_tensors, target_local_tensors, all_chunks, all_buckets
             if device == "cuda":
                 torch.cuda.empty_cache()
 
         # Generate plot for current mesh
         if rank == 0 and current_results:
-            generate_result_plot(current_results, source_mesh_shape, target_mesh_shape, mesh_idx)
+            generate_result_plot(
+                current_results,
+                source_mesh_shape,
+                target_mesh_shape,
+                mesh_idx,
+                num_tensors_per_batch,
+                source_specs,
+                target_specs,
+            )
             all_results[f"mesh_{mesh_idx + 1}_{source_mesh_shape}_{target_mesh_shape}"] = current_results
             print(f"✅ Mesh combination {mesh_idx + 1} test completed")
 

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -30,6 +30,7 @@ class ProfilingSpec:
     profile_freq: int
     warmup_steps: int
     active_steps: int
+    enable_memory_snapshot: bool
 
 
 @contextlib.contextmanager

--- a/prototyping/distributed_model_transfer/inference.py
+++ b/prototyping/distributed_model_transfer/inference.py
@@ -21,7 +21,7 @@ from etha.tensor_bus import bootstrap_client
 
 # Configure logging
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.INFO,
     format="[%(asctime)s] [Worker %(process)d] [%(levelname)s] %(message)s",
     datefmt="%H:%M:%S",
 )
@@ -33,7 +33,7 @@ LOCAL_NAME = "distributed_inference"
 REMOTE_NAME = "distributed_training"
 
 # Distributed strategy configuration
-DISTRIBUTED_STRATEGY = os.environ.get("INFERENCE_STRATEGY", "hybrid_dp_mp")
+DISTRIBUTED_STRATEGY = os.environ.get("DISTRIBUTED_STRATEGY", "hybrid_dp_mp")
 MODEL_ID = os.environ.get("MODEL_ID", "Qwen/Qwen3-30B-A3B")
 
 MODEL_DTYPE = get_model_dtype_from_env()
@@ -116,7 +116,7 @@ def main():
         expected_world_size=EXPECTED_WORLD_SIZE,
         device_mesh=engine.device_mesh,
         placements=tuple(engine.placements),
-        timeout=100,
+        timeout=1000,
     )
     logger.info(f"✅ Pair '{PAIR_NAME}' registered successfully!")
     # Register the distributed tensor
@@ -132,6 +132,7 @@ def main():
     sem = handler.register_tensor_batch(
         tensor_names=tensor_names,
         tensors=tensor_data,
+        bucket_size=256 * 1024 * 1024,
         blocking=False,
     )
     sem.acquire()

--- a/prototyping/distributed_model_transfer/train.py
+++ b/prototyping/distributed_model_transfer/train.py
@@ -33,7 +33,7 @@ LOCAL_NAME = "distributed_training"
 REMOTE_NAME = "distributed_inference"
 
 # Distributed strategy configuration
-DISTRIBUTED_STRATEGY = os.environ.get("TRAINING_STRATEGY", "pure_mp")
+DISTRIBUTED_STRATEGY = os.environ.get("DISTRIBUTED_STRATEGY", "pure_mp")
 MODEL_ID = os.environ.get("MODEL_ID", "Qwen/Qwen3-30B-A3B")
 
 MODEL_DTYPE = get_model_dtype_from_env()
@@ -111,7 +111,7 @@ def main():
             expected_world_size=EXPECTED_WORLD_SIZE,
             device_mesh=trainer.device_mesh,
             placements=tuple(trainer.placements),
-            timeout=100,
+            timeout=1000,
         )
         logger.info(f"✅ Pair '{PAIR_NAME}' registered successfully!")
         # Register the distributed tensor
@@ -127,6 +127,7 @@ def main():
         sem = handler.register_tensor_batch(
             tensor_names=tensor_names,
             tensors=tensor_data,
+            bucket_size=256 * 1024 * 1024,
             blocking=False,
         )
         sem.acquire()

--- a/prototyping/distributed_tensor_transfer/launch.sh
+++ b/prototyping/distributed_tensor_transfer/launch.sh
@@ -16,7 +16,7 @@ mkdir -p ${LMDB_ROOT}
 mkdir -p ${LOG_ROOT}
 
 echo "🚀 Starting Agent processes (ranks 0-7) with torchrun..."
-pixi run torchrun --nproc_per_node=8 --master-port=39500 ${PIXI_PROJECT_ROOT}/prototyping/agent.py > ${PIXI_PROJECT_ROOT}/prototyping/distributed_tensor_transfer/logs/agent.log 2>&1 &
+pixi run torchrun --nproc_per_node=8 --master-port=39500 ${ROOT_BASE}/agent.py > ${LOG_ROOT}/agent.log 2>&1 &
 AGENT_PID=$!
 
 # Wait for agents to be ready
@@ -24,14 +24,14 @@ echo "⏳ Waiting for agents to initialize..."
 sleep 8
 
 echo "🔥 Starting Training workers (ranks 0-3) with torchrun..."
-TRAINING_STRATEGY=${TRAINING_STRATEGY:-"hybrid_dp_mp"} pixi run torchrun --nproc_per_node=4 --master-port=39501 \
-    ${PIXI_PROJECT_ROOT}/prototyping/distributed_tensor_transfer/train.py > ${PIXI_PROJECT_ROOT}/prototyping/distributed_tensor_transfer/logs/train.log 2>&1 &
+pixi run torchrun --nproc_per_node=4 --master-port=39501 \
+    ${ROOT_BASE}/distributed_tensor_transfer/train.py > ${LOG_ROOT}/train.log 2>&1 &
 TRAIN_PID=$!
 
 echo "⚡ Starting Inference workers (ranks 0-3) with RAY..."
 echo "   (Connecting to agents 4-7, expecting NCCL device ID issues)"
-AGENT_RANK_OFFSET=4 CUDA_VISIBLE_DEVICES=4,5,6,7 INFERENCE_STRATEGY=${INFERENCE_STRATEGY:-"hybrid_dp_mp"} pixi run python \
-    ${PIXI_PROJECT_ROOT}/prototyping/distributed_tensor_transfer/ray_inference.py > ${PIXI_PROJECT_ROOT}/prototyping/distributed_tensor_transfer/logs/ray_inference.log 2>&1 &
+AGENT_RANK_OFFSET=4 CUDA_VISIBLE_DEVICES=4,5,6,7 pixi run python \
+    ${ROOT_BASE}/distributed_tensor_transfer/ray_inference.py > ${LOG_ROOT}/inference.log 2>&1 &
 INFERENCE_PID=$!
 
 echo ""
@@ -41,9 +41,9 @@ echo "   - Training (torchrun):  PID $TRAIN_PID"
 echo "   - Inference (Ray):      PID $INFERENCE_PID"
 echo ""
 echo "📋 Monitor logs:"
-echo "   tail -f ${PIXI_PROJECT_ROOT}/prototyping/distributed_tensor_transfer/logs/agent.log"
-echo "   tail -f ${PIXI_PROJECT_ROOT}/prototyping/distributed_tensor_transfer/logs/train.log"
-echo "   tail -f ${PIXI_PROJECT_ROOT}/prototyping/distributed_tensor_transfer/logs/ray_inference.log"
+echo "   tail -f ${LOG_ROOT}/agent.log"
+echo "   tail -f ${LOG_ROOT}/train.log"
+echo "   tail -f ${LOG_ROOT}/inference.log"
 echo ""
 echo "Press Ctrl+C to stop all processes..."
 echo ""

--- a/prototyping/distributed_tensor_transfer/ray_inference.py
+++ b/prototyping/distributed_tensor_transfer/ray_inference.py
@@ -173,7 +173,10 @@ class InferenceActor:
 
         # Register the distributed tensor
         sem = self.handler.register_tensor(
-            tensor_name="distributed_param", tensor=self.engine.distributed_param.to_local(), blocking=False
+            tensor_name="distributed_param",
+            tensor=self.engine.distributed_param.to_local(),
+            bucket_size=256 * 1024 * 1024,
+            blocking=False,
         )
         sem.acquire()
         sem.close()
@@ -242,7 +245,7 @@ def main():
     world_size = 4
     master_port = 39502
     agent_rank_offset = 4
-    strategy = os.environ.get("INFERENCE_STRATEGY", "hybrid_dp_mp")
+    strategy = os.environ.get("DISTRIBUTED_STRATEGY", "hybrid_dp_mp")
     os.environ["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"] = "1"
 
     print("=" * 80)

--- a/prototyping/distributed_tensor_transfer/train.py
+++ b/prototyping/distributed_tensor_transfer/train.py
@@ -29,7 +29,7 @@ REMOTE_NAME = "distributed_inference"
 EXPECTED_WORLD_SIZE = 4
 
 # Distributed strategy configuration
-DISTRIBUTED_STRATEGY = os.environ.get("TRAINING_STRATEGY", "pure_mp")
+DISTRIBUTED_STRATEGY = os.environ.get("DISTRIBUTED_STRATEGY", "pure_mp")
 
 
 class DistributedTrainer:
@@ -103,7 +103,10 @@ def main():
 
     # Register the distributed tensor
     sem = handler.register_tensor(
-        tensor_name="distributed_param", tensor=trainer.distributed_param.to_local(), blocking=False
+        tensor_name="distributed_param",
+        tensor=trainer.distributed_param.to_local(),
+        bucket_size=256 * 1024 * 1024,
+        blocking=False,
     )
     sem.acquire()
     sem.close()

--- a/src/etha/comm/__init__.py
+++ b/src/etha/comm/__init__.py
@@ -1,15 +1,15 @@
 """Communication utilities."""
 
+from .get_chunks import map_to_chunk_ops
+from .get_buckets import chunk_to_bucket_ops
 from .get_m2m_map import get_m2m_map
-from .comm_methods import m2m_communicate, gather_broadcast_communicate
-from .get_chunk_ops import map_to_chunk_ops, bind_tensors_to_chunks
-from .comm_execution import execute_pipeline
+from .comm_methods import chunk_comm, bucket_comm, gather_broadcast_comm
 
 __all__ = [
     "get_m2m_map",
     "map_to_chunk_ops",
-    "bind_tensors_to_chunks",
-    "m2m_communicate",
-    "gather_broadcast_communicate",
-    "execute_pipeline",
+    "chunk_to_bucket_ops",
+    "chunk_comm",
+    "bucket_comm",
+    "gather_broadcast_comm",
 ]

--- a/src/etha/comm/bucket_execution.py
+++ b/src/etha/comm/bucket_execution.py
@@ -1,0 +1,197 @@
+"""Bucket communication executor."""
+
+import logging
+from collections import deque
+
+import torch
+import torch.distributed as dist
+
+from .ir import Bucket, TransferType
+from .utils import get_or_create_process_group
+from .chunk_execution import _assemble_chunk, _prepare_recv_buffer, _prepare_send_buffer
+
+logger = logging.getLogger(__name__)
+rank = 0
+
+
+def _prepare_source_bucket(bucket: Bucket) -> None:
+    if len(bucket.offsets) == 1:
+        logger.debug(f"[rank={rank}] Bucket execution: Preparing source bucket with one offset")
+        _, length, chunk, _ = bucket.offsets[0]
+        _prepare_send_buffer(chunk)
+        bucket.buffer = chunk.buffer
+        chunk.buffer = None
+        return
+
+    total_elems = bucket.offsets[-1][0] + bucket.offsets[-1][1]
+    bucket.buffer = torch.empty(total_elems, dtype=bucket.dtype, device=bucket.device)
+
+    for offset, length, chunk, _ in bucket.offsets:
+        _prepare_send_buffer(chunk)
+        flat = chunk.buffer.view(-1)
+        bucket.buffer.narrow(0, offset, length).copy_(flat, non_blocking=True)
+        chunk.buffer = None
+    event = torch.cuda.Event()
+    event.record(torch.cuda.current_stream(bucket.buffer.device))
+    bucket.buffer_ready_event = event
+
+
+def _prepare_target_bucket(bucket: Bucket) -> None:
+    if len(bucket.offsets) == 1:
+        logger.debug(f"[rank={rank}] Bucket execution: Preparing target bucket with one offset")
+        _, length, chunk, _ = bucket.offsets[0]
+        _prepare_recv_buffer(chunk)
+        bucket.buffer = chunk.buffer
+        return
+
+    total_elems = bucket.offsets[-1][0] + bucket.offsets[-1][1]
+    bucket.buffer = torch.empty(total_elems, dtype=bucket.dtype, device=bucket.device)
+
+    for offset, length, chunk, shape in bucket.offsets:
+        view = bucket.buffer.narrow(0, offset, length).view(shape)
+        if bucket.transfer_type == TransferType.SELF_COPY:
+            if chunk.tensor is None:
+                raise ValueError("Self-copy chunk requires bound tensor.")
+            view.copy_(chunk.tensor[chunk.src_slice_tuples], non_blocking=True)
+        chunk.buffer = view
+    if bucket.transfer_type == TransferType.SELF_COPY:
+        event = torch.cuda.Event()
+        event.record(torch.cuda.current_stream(bucket.buffer.device))
+        bucket.buffer_ready_event = event
+
+
+def _prepare_bucket(bucket: Bucket) -> None:
+    if bucket.is_source:
+        _prepare_source_bucket(bucket)
+    else:
+        _prepare_target_bucket(bucket)
+
+
+def _bucket_key(bucket: Bucket) -> tuple:
+    chunk = bucket.offsets[0][2]
+    if bucket.is_source:
+        return chunk.src_idx
+    return chunk.dst_idx
+
+
+def _launch_bucket(bucket: Bucket) -> bool:
+    if bucket.buffer_ready_event is not None:
+        if not bucket.buffer_ready_event.query():
+            return False
+        bucket.buffer_ready_event = None
+
+    match bucket.transfer_type:
+        case TransferType.SELF_COPY:
+            bucket.work = None
+            return True
+
+        case TransferType.BROADCAST:
+            if bucket.group_key is None:
+                raise ValueError("Broadcast bucket missing process group key.")
+            group_ranks = sorted([bucket.group_key[0], *bucket.group_key[1]])
+            group = get_or_create_process_group(group_ranks)
+            src_rank = bucket.src_rank if bucket.is_source else bucket.group_key[0]
+            bucket.work = dist.broadcast(bucket.buffer, src=src_rank, group=group, async_op=True)
+
+        case TransferType.P2P:
+            if bucket.is_source:
+                if not bucket.dst_ranks or len(bucket.dst_ranks) != 1:
+                    raise ValueError("P2P bucket must have exactly one destination rank.")
+                logger.debug(
+                    f"[rank={rank}] Bucket execution: Launching P2P send to rank {bucket.dst_ranks[0]} buffer shape {bucket.buffer.shape} buffer dtype {bucket.buffer.dtype} buffer device {bucket.buffer.device}"
+                )
+                bucket.work = dist.isend(bucket.buffer, dst=bucket.dst_ranks[0])
+            else:
+                logger.debug(
+                    f"[rank={rank}] Bucket execution: Launching P2P receive from rank {bucket.src_rank} buffer shape {bucket.buffer.shape} buffer dtype {bucket.buffer.dtype} buffer device {bucket.buffer.device}"
+                )
+                bucket.work = dist.irecv(bucket.buffer, src=bucket.src_rank)
+    return True
+
+
+def _is_bucket_complete(bucket: Bucket) -> bool:
+    if bucket.work is None:
+        return True
+    if bucket.device is not None and bucket.device.type == "cpu":  # cpu device do not is_completed()
+        bucket.work.wait()
+        bucket.work = None
+        return True
+    return bucket.work.is_completed()
+
+
+def _finalize_bucket(bucket: Bucket) -> None:
+    if bucket.work is not None:
+        bucket.work.wait()
+        bucket.work = None
+
+    if bucket.is_source:
+        bucket.buffer = None
+        return
+
+    for _, _, chunk, _ in bucket.offsets:
+        _assemble_chunk(chunk)
+
+    bucket.buffer = None
+
+
+def execute_bucket_pipeline(
+    buckets: list[Bucket],
+    max_in_flight: int,
+) -> None:
+    if not buckets:
+        return
+    global rank
+    rank = dist.get_rank()
+
+    key_states: dict[tuple, dict[str, deque]] = {}
+    key_order: list[tuple] = []
+
+    for bucket in buckets:
+        key = _bucket_key(bucket)
+        if key not in key_states:
+            key_states[key] = {
+                "candidate": deque(),
+                "prepared": deque(),
+                "in_flight": deque(),
+            }
+            key_order.append(key)
+        key_states[key]["candidate"].append(bucket)
+    logger.debug(f"[rank={rank}] Bucket execution: Key states: {key_states}")
+
+    def _has_work() -> bool:
+        for state in key_states.values():
+            if state["candidate"] or state["prepared"] or state["in_flight"]:
+                return True
+        return False
+
+    while _has_work():
+        for key in key_order:
+            state = key_states[key]
+            candidate: deque = state["candidate"]
+            prepared: deque = state["prepared"]
+            in_flight: deque = state["in_flight"]
+
+            while candidate and len(prepared) + len(in_flight) < max_in_flight:
+                bucket = candidate.popleft()
+                logger.debug(f"[rank={rank}] Bucket execution: Preparing bucket {bucket}")
+                _prepare_bucket(bucket)
+                prepared.append(bucket)
+
+        for key in key_order:
+            state = key_states[key]
+            prepared: deque = state["prepared"]
+            in_flight: deque = state["in_flight"]
+
+            while prepared:
+                if not _launch_bucket(prepared[0]):
+                    break
+                logger.debug(f"[rank={rank}] Bucket execution: Launching bucket {prepared[0]}")
+                in_flight.append(prepared.popleft())
+
+        for key in key_order:
+            in_flight: deque = key_states[key]["in_flight"]
+            while in_flight:
+                if not _is_bucket_complete(in_flight[0]):
+                    break
+                logger.debug(f"[rank={rank}] Bucket execution: Finalizing bucket {in_flight[0]}")
+                _finalize_bucket(in_flight.popleft())

--- a/src/etha/comm/bucket_execution.py
+++ b/src/etha/comm/bucket_execution.py
@@ -1,62 +1,58 @@
 """Bucket communication executor."""
 
 import logging
-from collections import deque
+from collections import deque, defaultdict
 
 import torch
 import torch.distributed as dist
 
 from .ir import Bucket, TransferType
 from .utils import get_or_create_process_group
-from .chunk_execution import _assemble_chunk, _prepare_recv_buffer, _prepare_send_buffer
+from .chunk_execution import _prepare_chunk, _finalize_chunk
 
 logger = logging.getLogger(__name__)
-rank = 0
+rank = None
 
 
 def _prepare_source_bucket(bucket: Bucket) -> None:
-    if len(bucket.offsets) == 1:
-        logger.debug(f"[rank={rank}] Bucket execution: Preparing source bucket with one offset")
-        _, length, chunk, _ = bucket.offsets[0]
-        _prepare_send_buffer(chunk)
+    if len(bucket.entries) == 1:
+        chunk = bucket.entries[0].chunk
+        _prepare_chunk(chunk)
         bucket.buffer = chunk.buffer
         chunk.buffer = None
         return
 
-    total_elems = bucket.offsets[-1][0] + bucket.offsets[-1][1]
-    bucket.buffer = torch.empty(total_elems, dtype=bucket.dtype, device=bucket.device)
+    bucket.buffer = torch.empty(bucket.total_elems, dtype=bucket.dtype, device=bucket.device)
 
-    for offset, length, chunk, _ in bucket.offsets:
-        _prepare_send_buffer(chunk)
+    for entry in bucket.entries:
+        chunk = entry.chunk
+        _prepare_chunk(chunk)
         flat = chunk.buffer.view(-1)
-        bucket.buffer.narrow(0, offset, length).copy_(flat, non_blocking=True)
+        bucket.buffer.narrow(0, entry.offset, entry.numel).copy_(flat, non_blocking=True)
         chunk.buffer = None
     event = torch.cuda.Event()
-    event.record(torch.cuda.current_stream(bucket.buffer.device))
+    event.record()
     bucket.buffer_ready_event = event
 
 
 def _prepare_target_bucket(bucket: Bucket) -> None:
-    if len(bucket.offsets) == 1:
-        logger.debug(f"[rank={rank}] Bucket execution: Preparing target bucket with one offset")
-        _, length, chunk, _ = bucket.offsets[0]
-        _prepare_recv_buffer(chunk)
+    if len(bucket.entries) == 1:
+        chunk = bucket.entries[0].chunk
+        _prepare_chunk(chunk)
         bucket.buffer = chunk.buffer
         return
 
-    total_elems = bucket.offsets[-1][0] + bucket.offsets[-1][1]
-    bucket.buffer = torch.empty(total_elems, dtype=bucket.dtype, device=bucket.device)
+    bucket.buffer = torch.empty(bucket.total_elems, dtype=bucket.dtype, device=bucket.device)
 
-    for offset, length, chunk, shape in bucket.offsets:
-        view = bucket.buffer.narrow(0, offset, length).view(shape)
+    for entry in bucket.entries:
+        chunk = entry.chunk
+        view = bucket.buffer.narrow(0, entry.offset, entry.numel).view(chunk.chunk_shape)
         if bucket.transfer_type == TransferType.SELF_COPY:
-            if chunk.tensor is None:
-                raise ValueError("Self-copy chunk requires bound tensor.")
             view.copy_(chunk.tensor[chunk.src_slice_tuples], non_blocking=True)
         chunk.buffer = view
     if bucket.transfer_type == TransferType.SELF_COPY:
         event = torch.cuda.Event()
-        event.record(torch.cuda.current_stream(bucket.buffer.device))
+        event.record()
         bucket.buffer_ready_event = event
 
 
@@ -65,13 +61,6 @@ def _prepare_bucket(bucket: Bucket) -> None:
         _prepare_source_bucket(bucket)
     else:
         _prepare_target_bucket(bucket)
-
-
-def _bucket_key(bucket: Bucket) -> tuple:
-    chunk = bucket.offsets[0][2]
-    if bucket.is_source:
-        return chunk.src_idx
-    return chunk.dst_idx
 
 
 def _launch_bucket(bucket: Bucket) -> bool:
@@ -83,28 +72,16 @@ def _launch_bucket(bucket: Bucket) -> bool:
     match bucket.transfer_type:
         case TransferType.SELF_COPY:
             bucket.work = None
-            return True
 
         case TransferType.BROADCAST:
-            if bucket.group_key is None:
-                raise ValueError("Broadcast bucket missing process group key.")
-            group_ranks = sorted([bucket.group_key[0], *bucket.group_key[1]])
+            group_ranks = sorted([bucket.src_rank, *bucket.dst_ranks])
             group = get_or_create_process_group(group_ranks)
-            src_rank = bucket.src_rank if bucket.is_source else bucket.group_key[0]
-            bucket.work = dist.broadcast(bucket.buffer, src=src_rank, group=group, async_op=True)
+            bucket.work = dist.broadcast(bucket.buffer, src=bucket.src_rank, group=group, async_op=True)
 
         case TransferType.P2P:
             if bucket.is_source:
-                if not bucket.dst_ranks or len(bucket.dst_ranks) != 1:
-                    raise ValueError("P2P bucket must have exactly one destination rank.")
-                logger.debug(
-                    f"[rank={rank}] Bucket execution: Launching P2P send to rank {bucket.dst_ranks[0]} buffer shape {bucket.buffer.shape} buffer dtype {bucket.buffer.dtype} buffer device {bucket.buffer.device}"
-                )
                 bucket.work = dist.isend(bucket.buffer, dst=bucket.dst_ranks[0])
             else:
-                logger.debug(
-                    f"[rank={rank}] Bucket execution: Launching P2P receive from rank {bucket.src_rank} buffer shape {bucket.buffer.shape} buffer dtype {bucket.buffer.dtype} buffer device {bucket.buffer.device}"
-                )
                 bucket.work = dist.irecv(bucket.buffer, src=bucket.src_rank)
     return True
 
@@ -112,50 +89,44 @@ def _launch_bucket(bucket: Bucket) -> bool:
 def _is_bucket_complete(bucket: Bucket) -> bool:
     if bucket.work is None:
         return True
-    if bucket.device is not None and bucket.device.type == "cpu":  # cpu device do not is_completed()
+    if bucket.device is not None and bucket.device.type == "cpu":  # cpu device do not support is_completed()
         bucket.work.wait()
         bucket.work = None
         return True
     return bucket.work.is_completed()
 
 
-def _finalize_bucket(bucket: Bucket) -> None:
+def _finalize_bucket(bucket: Bucket) -> list[torch.cuda.Event]:
+    events: list[torch.cuda.Event] = []
     if bucket.work is not None:
         bucket.work.wait()
         bucket.work = None
 
-    if bucket.is_source:
-        bucket.buffer = None
-        return
-
-    for _, _, chunk, _ in bucket.offsets:
-        _assemble_chunk(chunk)
+    if not bucket.is_source:
+        for entry in bucket.entries:
+            events.append(_finalize_chunk(entry.chunk))
 
     bucket.buffer = None
+
+    return events
 
 
 def execute_bucket_pipeline(
     buckets: list[Bucket],
-    max_in_flight: int,
+    max_in_flight: int = 2,
 ) -> None:
-    if not buckets:
-        return
     global rank
     rank = dist.get_rank()
 
-    key_states: dict[tuple, dict[str, deque]] = {}
-    key_order: list[tuple] = []
-
+    key_states: defaultdict[tuple, dict[str, deque]] = defaultdict(
+        lambda: {
+            "candidate": deque(),
+            "prepared": deque(),
+            "in_flight": deque(),
+        }
+    )
     for bucket in buckets:
-        key = _bucket_key(bucket)
-        if key not in key_states:
-            key_states[key] = {
-                "candidate": deque(),
-                "prepared": deque(),
-                "in_flight": deque(),
-            }
-            key_order.append(key)
-        key_states[key]["candidate"].append(bucket)
+        key_states[bucket.key]["candidate"].append(bucket)
     logger.debug(f"[rank={rank}] Bucket execution: Key states: {key_states}")
 
     def _has_work() -> bool:
@@ -164,9 +135,9 @@ def execute_bucket_pipeline(
                 return True
         return False
 
+    events: list[torch.cuda.Event] = []
     while _has_work():
-        for key in key_order:
-            state = key_states[key]
+        for state in key_states.values():
             candidate: deque = state["candidate"]
             prepared: deque = state["prepared"]
             in_flight: deque = state["in_flight"]
@@ -177,8 +148,7 @@ def execute_bucket_pipeline(
                 _prepare_bucket(bucket)
                 prepared.append(bucket)
 
-        for key in key_order:
-            state = key_states[key]
+        for state in key_states.values():
             prepared: deque = state["prepared"]
             in_flight: deque = state["in_flight"]
 
@@ -188,10 +158,13 @@ def execute_bucket_pipeline(
                 logger.debug(f"[rank={rank}] Bucket execution: Launching bucket {prepared[0]}")
                 in_flight.append(prepared.popleft())
 
-        for key in key_order:
-            in_flight: deque = key_states[key]["in_flight"]
+        for state in key_states.values():
+            in_flight: deque = state["in_flight"]
             while in_flight:
                 if not _is_bucket_complete(in_flight[0]):
                     break
                 logger.debug(f"[rank={rank}] Bucket execution: Finalizing bucket {in_flight[0]}")
-                _finalize_bucket(in_flight.popleft())
+                events.extend(_finalize_bucket(in_flight.popleft()))
+
+    for event in events:
+        event.wait()

--- a/src/etha/comm/chunk_execution.py
+++ b/src/etha/comm/chunk_execution.py
@@ -7,198 +7,53 @@ from .ir import SourceChunk, TargetChunk, TransferType
 from .utils import get_or_create_process_group
 
 
-def _prepare_send_buffer(chunk: SourceChunk) -> None:
-    """Prepare send buffer for a single SourceChunk.
-
-    Args:
-        chunk: SourceChunk to prepare (must have .tensor bound)
-    """
+def _prepare_chunk(chunk: SourceChunk | TargetChunk) -> None:
     match chunk.transfer_type:
         case TransferType.SELF_COPY:
-            pass
+            if isinstance(chunk, TargetChunk):
+                chunk.buffer = chunk.tensor[chunk.src_slice_tuples]
         case _:
-            if chunk.tensor is None:
-                raise ValueError("SourceChunk has no tensor bound. Call bind_tensors_to_chunks() first.")
             chunk.buffer = chunk.tensor[chunk.slice_tuples].contiguous()
-    if chunk.target_dtype != chunk.buffer.dtype:
-        if chunk.target_dtype == torch.float8_e4m3fn:
-            raise NotImplementedError("float8 not supported")
+    if isinstance(chunk, SourceChunk) and chunk.target_dtype != chunk.buffer.dtype:
         chunk.buffer = chunk.buffer.to(chunk.target_dtype)
 
 
-def _prepare_recv_buffer(chunk: TargetChunk) -> None:
-    """Prepare receive buffer for a single TargetChunk.
-
-    Args:
-        chunk: TargetChunk to prepare.
-    """
-    if chunk.tensor is None:
-        raise ValueError("TargetChunk has no tensor bound. Call bind_tensors_to_chunks() first.")
-
-    match chunk.transfer_type:
-        case TransferType.SELF_COPY:
-            chunk.buffer = chunk.tensor[chunk.src_slice_tuples]
-        case _:
-            chunk.buffer = chunk.tensor[chunk.slice_tuples].contiguous()
-
-
-def _launch_send(chunk: SourceChunk) -> None:
-    """Launch async send operation, store work handle in chunk.
-
-    Args:
-        chunk: SourceChunk with buffer prepared (modified in-place)
-    """
-    match chunk.transfer_type:
-        case TransferType.SELF_COPY:
-            chunk.work = None
-        case TransferType.BROADCAST:
-            group_ranks = sorted([chunk.src_rank] + chunk.dst_ranks)
-            group = get_or_create_process_group(group_ranks)
-            chunk.work = dist.broadcast(tensor=chunk.buffer, src=chunk.src_rank, group=group, async_op=True)
-        case TransferType.P2P:
-            assert len(chunk.dst_ranks) == 1, f"P2P should have exactly 1 dst_rank, got {len(chunk.dst_ranks)}"
-            chunk.work = dist.isend(tensor=chunk.buffer, dst=chunk.dst_ranks[0])
-
-
-def _launch_recv(chunk: TargetChunk) -> None:
-    """Launch async receive operation, store work handle in chunk.
-
-    Args:
-        chunk: TargetChunk with buffer allocated (modified in-place)
-    """
-    match chunk.transfer_type:
-        case TransferType.SELF_COPY:
-            chunk.work = None
-        case TransferType.BROADCAST:
-            # group_key is (src_rank, tuple(sorted(dst_ranks))); construct subgroup in sorted order
-            src_rank, dst_tuple = chunk.group_key
-            group_ranks = sorted([src_rank] + list(dst_tuple))
-            group = get_or_create_process_group(group_ranks)
-            chunk.work = dist.broadcast(tensor=chunk.buffer, src=src_rank, group=group, async_op=True)
-        case TransferType.P2P:
-            chunk.work = dist.irecv(tensor=chunk.buffer, src=chunk.src_rank)
-
-
-def _assemble_chunk(chunk: TargetChunk) -> None:
-    """Wait for recv to complete, assemble chunk into final tensor, and cleanup.
-
-    Args:
-        chunk: TargetChunk to assemble (must have .tensor bound)
-    """
-    # Wait for async recv to complete
-    if chunk.work is not None:
-        chunk.work.wait()
-        chunk.work = None
-
-    chunk.tensor[chunk.slice_tuples].copy_(chunk.buffer)
-    chunk.buffer = None
-
-
-def _cleanup_send_chunk(chunk: SourceChunk) -> None:
-    """Wait for send to complete and cleanup buffer.
-
-    Args:
-        chunk: SourceChunk to cleanup
-    """
-    # Wait for async send to complete
-    if chunk.work is not None:
-        chunk.work.wait()
-        chunk.work = None
-
-    chunk.buffer = None
-
-
-def _prepare_chunk(chunk: SourceChunk | TargetChunk) -> None:
-    """Prepare buffer for a chunk (polymorphic)."""
-    if isinstance(chunk, SourceChunk):
-        _prepare_send_buffer(chunk)
-    else:
-        _prepare_recv_buffer(chunk)
-
-
 def _launch_chunk(chunk: SourceChunk | TargetChunk) -> None:
-    """Launch async operation for a chunk (polymorphic)."""
-    if isinstance(chunk, SourceChunk):
-        _launch_send(chunk)
-    else:
-        _launch_recv(chunk)
+    match chunk.transfer_type:
+        case TransferType.SELF_COPY:
+            chunk.work = None
+        case TransferType.BROADCAST:
+            group_ranks = sorted([chunk.src_rank, *chunk.dst_ranks])
+            group = get_or_create_process_group(group_ranks)
+            chunk.work = dist.broadcast(chunk.buffer, src=chunk.src_rank, group=group, async_op=True)
+        case TransferType.P2P:
+            if isinstance(chunk, SourceChunk):
+                chunk.work = dist.isend(chunk.buffer, dst=chunk.dst_ranks[0])
+            else:
+                chunk.work = dist.irecv(chunk.buffer, src=chunk.src_rank)
 
 
-def _cleanup_chunk(chunk: SourceChunk | TargetChunk) -> None:
-    """Cleanup and assemble chunk (polymorphic)."""
-    if isinstance(chunk, SourceChunk):
-        _cleanup_send_chunk(chunk)
-    else:
-        _assemble_chunk(chunk)
+def _finalize_chunk(chunk: SourceChunk | TargetChunk) -> torch.cuda.Event:
+    if chunk.work is not None:
+        chunk.work.wait()
+        chunk.work = None
+
+    if isinstance(chunk, TargetChunk):
+        chunk.tensor[chunk.slice_tuples].copy_(chunk.buffer, non_blocking=True)
+
+    chunk.buffer = None
+
+    event = torch.cuda.Event()
+    event.record()
+
+    return event
 
 
-def _is_complete(chunk: SourceChunk | TargetChunk) -> bool:
-    """Check if async operation is complete."""
-    if chunk.work is None:
-        return True
-    return chunk.work.is_completed()
-
-
-def execute_chunk_pipeline(
+def execute_chunk_simple(
     chunks: list[SourceChunk | TargetChunk],
-    max_in_flight: int,
 ) -> None:
-    """Execute chunks with polling-based producer-consumer pipeline.
-
-    Three queues:
-    - candidate: chunks waiting to be prepared
-    - prepared: chunks with buffers ready, waiting to launch
-    - in_flight: chunks with async operations running
-
-    Constraint: len(prepared) + len(in_flight) <= max_in_flight
-
-    This enables true overlap between buffer preparation and async operations
-    without relying on stage_id grouping.
-
-    Args:
-        chunks: Unified list of SourceChunk and TargetChunk operations
-        max_in_flight: Maximum combined size of prepared + in_flight queues
-    """
-    if not chunks:
-        return
-
-    # Initialize three queues
-    candidate = chunks.copy()  # shallow copy
-    prepared: list[SourceChunk | TargetChunk] = []
-    in_flight: list[SourceChunk | TargetChunk] = []
-
-    # Main polling loop
-    with torch.profiler.record_function("m2m::polling_loop"):
-        while prepared or in_flight or candidate:
-            # Prepare chunks if there is space
-            with torch.profiler.record_function("m2m::prepare_phase"):
-                while candidate and len(prepared) + len(in_flight) < max_in_flight:
-                    chunk = candidate.pop(0)
-                    _prepare_chunk(chunk)
-                    prepared.append(chunk)
-
-            # Launch chunks in prepared queue
-            with torch.profiler.record_function("m2m::launch_phase"):
-                while prepared:
-                    chunk = prepared.pop(0)
-                    _launch_chunk(chunk)
-                    in_flight.append(chunk)
-
-            # Poll in_flight for completions (non-blocking)
-            with torch.profiler.record_function("m2m::poll_completions"):
-                completed_indices = []
-                for i, chunk in enumerate(in_flight):
-                    if _is_complete(chunk):
-                        completed_indices.append(i)
-
-            # Clean up completed chunks (iterate in reverse to maintain indices)
-            with torch.profiler.record_function("m2m::cleanup_phase"):
-                for i in reversed(completed_indices):
-                    chunk = in_flight.pop(i)
-                    _cleanup_chunk(chunk)
-
-            # If nothing completed and we still have work, wait for at least one to complete
-            if not completed_indices and in_flight:
-                with torch.profiler.record_function("m2m::blocking_wait"):
-                    chunk = in_flight.pop(0)
-                    _cleanup_chunk(chunk)
+    for chunk in chunks:
+        _prepare_chunk(chunk)
+        _launch_chunk(chunk)
+        event = _finalize_chunk(chunk)
+        event.wait()

--- a/src/etha/comm/chunk_execution.py
+++ b/src/etha/comm/chunk_execution.py
@@ -139,9 +139,9 @@ def _is_complete(chunk: SourceChunk | TargetChunk) -> bool:
     return chunk.work.is_completed()
 
 
-def execute_pipeline(
+def execute_chunk_pipeline(
     chunks: list[SourceChunk | TargetChunk],
-    max_in_flight: int = 4,
+    max_in_flight: int,
 ) -> None:
     """Execute chunks with polling-based producer-consumer pipeline.
 
@@ -167,17 +167,17 @@ def execute_pipeline(
     prepared: list[SourceChunk | TargetChunk] = []
     in_flight: list[SourceChunk | TargetChunk] = []
 
-    # Pre-fill prepared queue up to max_in_flight
-    with torch.profiler.record_function("m2m::prefill_prepare"):
-        while candidate and len(prepared) < max_in_flight:
-            chunk = candidate.pop(0)
-            _prepare_chunk(chunk)
-            prepared.append(chunk)
-
     # Main polling loop
     with torch.profiler.record_function("m2m::polling_loop"):
         while prepared or in_flight or candidate:
-            # Launch prepared chunks if there's room in in_flight
+            # Prepare chunks if there is space
+            with torch.profiler.record_function("m2m::prepare_phase"):
+                while candidate and len(prepared) + len(in_flight) < max_in_flight:
+                    chunk = candidate.pop(0)
+                    _prepare_chunk(chunk)
+                    prepared.append(chunk)
+
+            # Launch chunks in prepared queue
             with torch.profiler.record_function("m2m::launch_phase"):
                 while prepared:
                     chunk = prepared.pop(0)
@@ -196,13 +196,6 @@ def execute_pipeline(
                 for i in reversed(completed_indices):
                     chunk = in_flight.pop(i)
                     _cleanup_chunk(chunk)
-
-            # Prepare more chunks if we have space
-            with torch.profiler.record_function("m2m::prepare_phase"):
-                while candidate and len(prepared) < max_in_flight:
-                    chunk = candidate.pop(0)
-                    _prepare_chunk(chunk)
-                    prepared.append(chunk)
 
             # If nothing completed and we still have work, wait for at least one to complete
             if not completed_indices and in_flight:

--- a/src/etha/comm/comm_methods.py
+++ b/src/etha/comm/comm_methods.py
@@ -7,13 +7,14 @@ import torch.distributed as dist
 from torch.distributed._tensor import DTensor, DeviceMesh, distribute_tensor
 from torch.distributed.tensor.placement_types import Placement
 
-from .ir import SourceChunk, TargetChunk
-from .comm_execution import execute_pipeline
+from .ir import Bucket, SourceChunk, TargetChunk
+from .chunk_execution import execute_chunk_pipeline
+from .bucket_execution import execute_bucket_pipeline
 
 logger = logging.getLogger(__name__)
 
 
-def gather_broadcast_communicate(
+def gather_broadcast_comm(
     target_mesh: DeviceMesh,
     target_specs: tuple[Placement, ...],
     local_tensor: DTensor,
@@ -50,9 +51,9 @@ def gather_broadcast_communicate(
     return received_tensor
 
 
-def m2m_communicate(
+def chunk_comm(
     chunks: list[SourceChunk | TargetChunk],
-    max_in_flight: int = 4,
+    max_in_flight: int = 8,
 ) -> None:
     """Execute mesh-to-mesh communication using pre-compiled chunk IR.
 
@@ -66,4 +67,12 @@ def m2m_communicate(
     Returns:
         None (result is written to target tensor in-place)
     """
-    execute_pipeline(chunks=chunks, max_in_flight=max_in_flight)
+    execute_chunk_pipeline(chunks=chunks, max_in_flight=max_in_flight)
+
+
+def bucket_comm(
+    buckets: list[Bucket],
+    max_in_flight: int = 2,
+) -> None:
+    """Execute bucketized communication."""
+    execute_bucket_pipeline(buckets=buckets, max_in_flight=max_in_flight)

--- a/src/etha/comm/comm_methods.py
+++ b/src/etha/comm/comm_methods.py
@@ -8,7 +8,7 @@ from torch.distributed._tensor import DTensor, DeviceMesh, distribute_tensor
 from torch.distributed.tensor.placement_types import Placement
 
 from .ir import Bucket, SourceChunk, TargetChunk
-from .chunk_execution import execute_chunk_pipeline
+from .chunk_execution import execute_chunk_simple
 from .bucket_execution import execute_bucket_pipeline
 
 logger = logging.getLogger(__name__)
@@ -53,26 +53,13 @@ def gather_broadcast_comm(
 
 def chunk_comm(
     chunks: list[SourceChunk | TargetChunk],
-    max_in_flight: int = 8,
 ) -> None:
-    """Execute mesh-to-mesh communication using pre-compiled chunk IR.
-
-    Uses polling-based producer-consumer pipeline for dynamic execution.
-    Chunks must have tensor references bound before calling this function.
-
-    Args:
-        chunks: Unified list of SourceChunk and TargetChunk operations
-        max_in_flight: Maximum chunks in prepared+in_flight queues
-
-    Returns:
-        None (result is written to target tensor in-place)
-    """
-    execute_chunk_pipeline(chunks=chunks, max_in_flight=max_in_flight)
+    """Execute chunked communication."""
+    execute_chunk_simple(chunks=chunks)
 
 
 def bucket_comm(
     buckets: list[Bucket],
-    max_in_flight: int = 2,
 ) -> None:
     """Execute bucketized communication."""
-    execute_bucket_pipeline(buckets=buckets, max_in_flight=max_in_flight)
+    execute_bucket_pipeline(buckets=buckets)

--- a/src/etha/comm/get_buckets.py
+++ b/src/etha/comm/get_buckets.py
@@ -1,0 +1,85 @@
+"""Get buckets from chunks."""
+
+import math
+from collections import defaultdict
+
+import torch
+
+from .ir import Bucket, SourceChunk, TargetChunk
+
+
+def _chunk_nbytes(chunk: SourceChunk | TargetChunk) -> int:
+    dtype = chunk.target_dtype if isinstance(chunk, SourceChunk) else chunk.tensor.dtype
+    element_size = torch.empty((), dtype=dtype).element_size()
+    return math.prod(chunk.chunk_shape) * element_size
+
+
+def _bucket_key(chunk: SourceChunk | TargetChunk) -> tuple:
+    if isinstance(chunk, SourceChunk):
+        return chunk.src_idx
+    return chunk.dst_idx
+
+
+def _calculate_bucket_offsets(
+    grouped_chunks: list[SourceChunk | TargetChunk],
+) -> list[tuple[int, int, SourceChunk | TargetChunk, tuple[int, ...]]]:
+    offsets: list[tuple[int, int, SourceChunk | TargetChunk, tuple[int, ...]]] = []
+    cursor = 0
+    for chunk in grouped_chunks:
+        numel = math.prod(chunk.chunk_shape)
+        shape = tuple(int(dim) for dim in chunk.chunk_shape)
+        offsets.append((cursor, numel, chunk, shape))
+        cursor += numel
+    return offsets
+
+
+def _build_bucket(
+    offsets: list[tuple[int, int, SourceChunk | TargetChunk, tuple[int, ...]]],
+) -> Bucket:
+    first_chunk = offsets[0][2]
+    is_source = isinstance(first_chunk, SourceChunk)
+    dtype = first_chunk.target_dtype if is_source else first_chunk.tensor.dtype
+    device = first_chunk.tensor.device
+    transfer_type = first_chunk.transfer_type
+    dst_ranks = tuple(first_chunk.dst_ranks) if is_source else None
+    src_rank = first_chunk.src_rank
+    return Bucket(
+        transfer_type=transfer_type,
+        is_source=is_source,
+        dst_ranks=dst_ranks,
+        src_rank=src_rank,
+        group_key=first_chunk.group_key,
+        dtype=dtype,
+        device=device,
+        offsets=offsets,
+    )
+
+
+def chunk_to_bucket_ops(
+    chunks: list[SourceChunk | TargetChunk],
+    bucket_size: int,
+) -> list[Bucket]:
+    buckets: list[Bucket] = []
+    grouped_state: dict[tuple, tuple[list[SourceChunk | TargetChunk], int]] = defaultdict(lambda: ([], 0))
+    for chunk in chunks:
+        chunk_bytes = _chunk_nbytes(chunk)
+        if chunk_bytes >= bucket_size:
+            offsets = _calculate_bucket_offsets([chunk])
+            buckets.append(_build_bucket(offsets))
+            continue
+        key = _bucket_key(chunk)
+        current_chunks, current_bytes = grouped_state[key]
+        current_chunks.append(chunk)
+        current_bytes += chunk_bytes
+        if current_bytes >= bucket_size:
+            offsets = _calculate_bucket_offsets(current_chunks)
+            buckets.append(_build_bucket(offsets))
+            grouped_state[key] = ([], 0)
+        else:
+            grouped_state[key] = (current_chunks, current_bytes)
+    for current_chunks, _ in grouped_state.values():
+        if not current_chunks:
+            continue
+        offsets = _calculate_bucket_offsets(current_chunks)
+        buckets.append(_build_bucket(offsets))
+    return buckets

--- a/src/etha/comm/get_buckets.py
+++ b/src/etha/comm/get_buckets.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 import torch
 
-from .ir import Bucket, SourceChunk, TargetChunk
+from .ir import Bucket, BucketEntry, SourceChunk, TargetChunk
 
 
 def _chunk_nbytes(chunk: SourceChunk | TargetChunk) -> int:
@@ -20,38 +20,40 @@ def _bucket_key(chunk: SourceChunk | TargetChunk) -> tuple:
     return chunk.dst_idx
 
 
-def _calculate_bucket_offsets(
+def _calculate_bucket_entries(
     grouped_chunks: list[SourceChunk | TargetChunk],
-) -> list[tuple[int, int, SourceChunk | TargetChunk, tuple[int, ...]]]:
-    offsets: list[tuple[int, int, SourceChunk | TargetChunk, tuple[int, ...]]] = []
+) -> list[BucketEntry]:
+    entries: list[BucketEntry] = []
     cursor = 0
     for chunk in grouped_chunks:
         numel = math.prod(chunk.chunk_shape)
-        shape = tuple(int(dim) for dim in chunk.chunk_shape)
-        offsets.append((cursor, numel, chunk, shape))
+        entries.append(BucketEntry(offset=cursor, numel=numel, chunk=chunk))
         cursor += numel
-    return offsets
+    return entries
 
 
 def _build_bucket(
-    offsets: list[tuple[int, int, SourceChunk | TargetChunk, tuple[int, ...]]],
+    entries: list[BucketEntry],
 ) -> Bucket:
-    first_chunk = offsets[0][2]
+    first_chunk = entries[0].chunk
     is_source = isinstance(first_chunk, SourceChunk)
     dtype = first_chunk.target_dtype if is_source else first_chunk.tensor.dtype
     device = first_chunk.tensor.device
     transfer_type = first_chunk.transfer_type
-    dst_ranks = tuple(first_chunk.dst_ranks) if is_source else None
+    dst_ranks = first_chunk.dst_ranks
     src_rank = first_chunk.src_rank
+    total_elems = entries[-1].offset + entries[-1].numel
+    key = _bucket_key(first_chunk)
     return Bucket(
         transfer_type=transfer_type,
         is_source=is_source,
         dst_ranks=dst_ranks,
         src_rank=src_rank,
-        group_key=first_chunk.group_key,
         dtype=dtype,
         device=device,
-        offsets=offsets,
+        key=key,
+        total_elems=total_elems,
+        entries=entries,
     )
 
 
@@ -61,25 +63,28 @@ def chunk_to_bucket_ops(
 ) -> list[Bucket]:
     buckets: list[Bucket] = []
     grouped_state: dict[tuple, tuple[list[SourceChunk | TargetChunk], int]] = defaultdict(lambda: ([], 0))
+
     for chunk in chunks:
         chunk_bytes = _chunk_nbytes(chunk)
         if chunk_bytes >= bucket_size:
-            offsets = _calculate_bucket_offsets([chunk])
-            buckets.append(_build_bucket(offsets))
+            entries = _calculate_bucket_entries([chunk])
+            buckets.append(_build_bucket(entries))
             continue
+
         key = _bucket_key(chunk)
         current_chunks, current_bytes = grouped_state[key]
         current_chunks.append(chunk)
         current_bytes += chunk_bytes
         if current_bytes >= bucket_size:
-            offsets = _calculate_bucket_offsets(current_chunks)
-            buckets.append(_build_bucket(offsets))
+            entries = _calculate_bucket_entries(current_chunks)
+            buckets.append(_build_bucket(entries))
             grouped_state[key] = ([], 0)
         else:
             grouped_state[key] = (current_chunks, current_bytes)
+
     for current_chunks, _ in grouped_state.values():
         if not current_chunks:
             continue
-        offsets = _calculate_bucket_offsets(current_chunks)
-        buckets.append(_build_bucket(offsets))
+        entries = _calculate_bucket_entries(current_chunks)
+        buckets.append(_build_bucket(entries))
     return buckets

--- a/src/etha/comm/get_chunks.py
+++ b/src/etha/comm/get_chunks.py
@@ -59,9 +59,8 @@ def map_to_chunk_ops(
                 transfer_type = TransferType.BROADCAST
             else:
                 transfer_type = TransferType.P2P
-            dst_ranks = sorted({r for r, _ in dst_list})
+            dst_ranks = tuple(sorted({r for r, _ in dst_list}))
             if src_rank == rank:
-                group_key = (rank, tuple(dst_ranks)) if transfer_type == TransferType.BROADCAST else None
                 slice_tuples = ()
                 if source_slicer_tuples is not None:
                     slice_tuples = get_slice_from_multi_index(
@@ -73,7 +72,6 @@ def map_to_chunk_ops(
                     src_rank=rank,
                     src_idx=src_idx,
                     dst_ranks=dst_ranks,
-                    group_key=group_key,
                     slice_tuples=slice_tuples,
                     tensor=source_tensor,
                     target_dtype=target_dtype,
@@ -83,13 +81,8 @@ def map_to_chunk_ops(
                 if dst_rank == rank:
                     if src_rank == rank:
                         actual_transfer_type = TransferType.SELF_COPY
-                        group_key = None
                     else:
                         actual_transfer_type = transfer_type
-                        if transfer_type == TransferType.BROADCAST:
-                            group_key = (src_rank, tuple(dst_ranks))
-                        else:
-                            group_key = None
                     slice_tuples = ()
                     if target_slicer_tuples is not None:
                         slice_tuples = get_slice_from_multi_index(
@@ -103,15 +96,13 @@ def map_to_chunk_ops(
                     target_chunk = TargetChunk(
                         chunk_shape=calculate_chunk_shape(target_num_slicers_extended, target_tensor_shape),
                         transfer_type=actual_transfer_type,
-                        dst_rank=rank,
+                        dst_ranks=dst_ranks,
                         dst_idx=dst_idx,
                         src_rank=src_rank,
                         src_idx=src_idx,
-                        group_key=group_key,
                         slice_tuples=slice_tuples,
                         src_slice_tuples=src_slice_tuples,
                         tensor=target_tensor,
-                        target_dtype=target_dtype,
                     )
                     chunks.append(target_chunk)
     return chunks

--- a/src/etha/comm/get_chunks.py
+++ b/src/etha/comm/get_chunks.py
@@ -1,8 +1,6 @@
-"""Convert transfer IR to chunk IR."""
+"""Get chunks from m2m map."""
 
 import torch
-
-from etha.comm.ir import SourceChunk, TargetChunk, logger
 
 from .ir import SourceChunk, TargetChunk, TransferType
 from .utils import (
@@ -16,57 +14,10 @@ def calculate_chunk_shape(
     num_slicers: list[int],
     tensor_shape: tuple[int, ...] | None,
 ) -> tuple[int, ...]:
-    """Calculate chunk shape from num_slicers and tensor shape.
-
-    Args:
-        num_slicers: Number of slices per dimension
-        tensor_shape: Full tensor shape (if known)
-
-    Returns:
-        Shape of the chunk, or empty tuple if tensor_shape is None
-    """
     if tensor_shape is None:
         return ()
-
-    # Extend num_slicers to match tensor dimensions
-    num_slicers = num_slicers + [1] * (len(tensor_shape) - len(num_slicers))
-
     chunk_shape = tuple(tensor_shape[dim] // num_slicers[dim] for dim in range(len(tensor_shape)))
-
     return chunk_shape
-
-
-def bind_tensors_to_chunks(
-    source_chunks: list[SourceChunk],
-    target_chunks: list[TargetChunk],
-    source_tensor: torch.Tensor | None = None,
-    target_tensor: torch.Tensor | None = None,
-) -> None:
-    """Bind tensor references to chunks (in-place operation).
-
-    This function transitions chunks from planning phase (tensor-agnostic) to
-    execution phase (tensor-bound). After binding, chunks are self-contained
-    and can be executed without passing tensors separately.
-
-    Args:
-        source_chunks: List of source chunks to bind (modified in-place)
-        target_chunks: List of target chunks to bind (modified in-place)
-        source_tensor: Tensor to bind to source chunks (None for receiver-only ranks)
-        target_tensor: Tensor to bind to target chunks (None for sender-only ranks)
-
-    Note:
-        This is an in-place operation. After calling this function, the chunks'
-        .tensor field will reference the provided tensors.
-    """
-    if source_tensor is not None:
-        for chunk in source_chunks:
-            chunk.tensor = source_tensor
-            logger.debug("Bound source tensor to chunk")
-
-    if target_tensor is not None:
-        for chunk in target_chunks:
-            chunk.tensor = target_tensor
-            logger.debug("Bound target tensor to chunk")
 
 
 def map_to_chunk_ops(
@@ -78,43 +29,20 @@ def map_to_chunk_ops(
     target_tensor: torch.Tensor | None = None,
     target_dtype: torch.dtype | None = None,
 ) -> list[SourceChunk | TargetChunk]:
-    """Convert M2MMap directly to execution-ready chunks.
-
-    Eliminates Transfer abstraction by directly generating chunks from M2MMap.
-    Returns a unified list of chunks (both source and target operations).
-
-    Args:
-        m2m_map: Communication topology {src_rank: {src_idx: [(dst_rank, dst_idx), ...]}}
-        rank: Current process rank
-        source_num_slicers: How source tensor is partitioned
-        target_num_slicers: How target tensor is partitioned
-        source_tensor: Tensor to bind for source chunks
-        target_tensor: Tensor to bind for target chunks
-
-    Returns:
-        Unified list of SourceChunk and TargetChunk objects
-    """
     if not m2m_map:
         return []
-
-    # Get tensor shapes from provided tensors
     source_tensor_shape = source_tensor.shape if source_tensor is not None else None
     target_tensor_shape = target_tensor.shape if target_tensor is not None else None
-
-    # Pre-calculate slicer tuples for slice indexing
     source_slicer_tuples = None
     source_num_slicers_extended = None
     if source_tensor_shape is not None:
         source_num_slicers_extended = (source_num_slicers + [1] * len(source_tensor_shape))[: len(source_tensor_shape)]
         source_slicer_tuples = get_slicer_tuples(source_tensor_shape, source_num_slicers_extended)
-
     target_slicer_tuples = None
     target_num_slicers_extended = None
     if target_tensor_shape is not None:
         target_num_slicers_extended = (target_num_slicers + [1] * len(target_tensor_shape))[: len(target_tensor_shape)]
         target_slicer_tuples = get_slicer_tuples(target_tensor_shape, target_num_slicers_extended)
-
-    # Pre-create broadcast process groups
     broadcast_groups = set()
     for src_rank, src_map in m2m_map.items():
         for _, dst_list in src_map.items():
@@ -122,35 +50,25 @@ def map_to_chunk_ops(
                 dst_ranks = sorted({r for r, _ in dst_list})
                 group_ranks = tuple([src_rank] + dst_ranks)
                 broadcast_groups.add(group_ranks)
-
     for group_ranks in sorted(broadcast_groups):
         get_or_create_process_group(list(group_ranks))
-
     chunks: list[SourceChunk | TargetChunk] = []
-
-    # Generate chunks from m2m_map
     for src_rank, src_map in m2m_map.items():
         for src_idx, dst_list in src_map.items():
-            # Determine transfer type
             if len(dst_list) > 1:
                 transfer_type = TransferType.BROADCAST
             else:
                 transfer_type = TransferType.P2P
-
             dst_ranks = sorted({r for r, _ in dst_list})
-
-            # === Generate SourceChunk if this rank is the sender ===
             if src_rank == rank:
                 group_key = (rank, tuple(dst_ranks)) if transfer_type == TransferType.BROADCAST else None
-
                 slice_tuples = ()
                 if source_slicer_tuples is not None:
                     slice_tuples = get_slice_from_multi_index(
                         src_idx, source_num_slicers_extended, source_slicer_tuples
                     )
-
                 source_chunk = SourceChunk(
-                    chunk_shape=calculate_chunk_shape(source_num_slicers, source_tensor_shape),
+                    chunk_shape=calculate_chunk_shape(source_num_slicers_extended, source_tensor_shape),
                     transfer_type=transfer_type,
                     src_rank=rank,
                     src_idx=src_idx,
@@ -160,14 +78,10 @@ def map_to_chunk_ops(
                     tensor=source_tensor,
                     target_dtype=target_dtype,
                 )
-
                 chunks.append(source_chunk)
-
-            # === Generate TargetChunks for each destination ===
             for dst_rank, dst_idx in dst_list:
                 if dst_rank == rank:
                     if src_rank == rank:
-                        # Self-copy case
                         actual_transfer_type = TransferType.SELF_COPY
                         group_key = None
                     else:
@@ -176,23 +90,18 @@ def map_to_chunk_ops(
                             group_key = (src_rank, tuple(dst_ranks))
                         else:
                             group_key = None
-
-                    # Pre-calculate slice_tuples
                     slice_tuples = ()
                     if target_slicer_tuples is not None:
                         slice_tuples = get_slice_from_multi_index(
                             dst_idx, target_num_slicers_extended, target_slicer_tuples
                         )
-
-                    # Pre-calculate src_slice_tuples for self_copy
                     src_slice_tuples = ()
                     if actual_transfer_type == TransferType.SELF_COPY and source_slicer_tuples is not None:
                         src_slice_tuples = get_slice_from_multi_index(
                             src_idx, source_num_slicers_extended, source_slicer_tuples
                         )
-
                     target_chunk = TargetChunk(
-                        chunk_shape=calculate_chunk_shape(target_num_slicers, target_tensor_shape),
+                        chunk_shape=calculate_chunk_shape(target_num_slicers_extended, target_tensor_shape),
                         transfer_type=actual_transfer_type,
                         dst_rank=rank,
                         dst_idx=dst_idx,
@@ -204,7 +113,5 @@ def map_to_chunk_ops(
                         tensor=target_tensor,
                         target_dtype=target_dtype,
                     )
-
                     chunks.append(target_chunk)
-
     return chunks

--- a/src/etha/comm/ir.py
+++ b/src/etha/comm/ir.py
@@ -38,25 +38,12 @@ class BaseChunk:
 
     slice_tuples: tuple[slice, ...] = ()  # Slice tuple for tensor indexing
 
-    target_dtype: torch.dtype | None = None
-
-
-@dataclass(slots=True, kw_only=True)
-class SourceChunk(BaseChunk):
-    """Source-side transfer chunk (send operations).
-
-    Represents a chunk of data to be sent from source rank to one or more target ranks.
-    """
-
     # Source info
     src_rank: int  # Rank that owns this data
     src_idx: tuple  # Multi-dimensional index in source tensor
 
     # Destination info
-    dst_ranks: list[int]  # Target ranks (len > 1 triggers broadcast)
-
-    # Broadcast info (None for self_copy and p2p)
-    group_key: tuple[int, tuple[int, ...]] | None = None  # (src_rank, tuple(sorted(dst_ranks)))
+    dst_ranks: tuple[int]  # Target ranks (len > 1 triggers broadcast)
 
     def __repr__(self) -> str:
         """Return a concise representation for debugging."""
@@ -69,6 +56,16 @@ class SourceChunk(BaseChunk):
 
 
 @dataclass(slots=True, kw_only=True)
+class SourceChunk(BaseChunk):
+    """Source-side transfer chunk (send operations).
+
+    Represents a chunk of data to be sent from source rank to one or more target ranks.
+    """
+
+    target_dtype: torch.dtype | None = None
+
+
+@dataclass(slots=True, kw_only=True)
 class TargetChunk(BaseChunk):
     """Target-side transfer chunk (receive + assemble operations).
 
@@ -76,26 +73,18 @@ class TargetChunk(BaseChunk):
     """
 
     # Target info
-    dst_rank: int  # Rank that will receive this data
     dst_idx: tuple  # Multi-dimensional index in target tensor
-
-    # Source info (where data comes from)
-    src_rank: int
-    src_idx: tuple  # Multi-dimensional index in source tensor
-
-    # Broadcast info (None for self_copy and p2p)
-    group_key: tuple[int, tuple[int, ...]] | None = None  # (src_rank, tuple(sorted(dst_ranks)))
 
     src_slice_tuples: tuple[slice, ...] = ()  # Slice tuple for source tensor (self_copy only)
 
-    def __repr__(self) -> str:
-        """Return a concise representation for debugging."""
-        return (
-            f"TargetChunk("
-            f"type={self.transfer_type.name[:3] if self.transfer_type else '???'}, "
-            f"src={self.src_rank}→dst={self.dst_rank}, "
-            f"tensor={self.tensor is not None})"
-        )
+
+@dataclass(slots=True, kw_only=True)
+class BucketEntry:
+    """Bucket offset entry."""
+
+    offset: int
+    numel: int
+    chunk: SourceChunk | TargetChunk
 
 
 @dataclass(slots=True, kw_only=True)
@@ -106,16 +95,16 @@ class Bucket:
     is_source: bool
     dst_ranks: tuple[int, ...] | None = None
     src_rank: int | None = None
-    group_key: tuple[int, tuple[int, ...]] | None = None
     dtype: torch.dtype | None = None
     device: torch.device | None = None
     buffer: torch.Tensor | None = None
     work: "torch.distributed.Work | None" = None
     buffer_ready_event: torch.cuda.Event | None = None
-    offsets: list[tuple[int, int, BaseChunk, tuple[int, ...]]]
+    total_elems: int
+    key: tuple
+    entries: list[BucketEntry]
 
     def __repr__(self) -> str:
         """Return a concise representation for debugging."""
         kind = "src" if self.is_source else "dst"
-        chunk_count = len(self.offsets)
-        return f"Bucket({kind}, chunks={chunk_count} src_rank={self.src_rank}→dst_ranks={self.dst_ranks})"
+        return f"Bucket({kind}, key={self.key} entries_len={len(self.entries)} src_rank={self.src_rank}→dst_ranks={self.dst_ranks})"

--- a/src/etha/comm/ir.py
+++ b/src/etha/comm/ir.py
@@ -96,3 +96,26 @@ class TargetChunk(BaseChunk):
             f"src={self.src_rank}→dst={self.dst_rank}, "
             f"tensor={self.tensor is not None})"
         )
+
+
+@dataclass(slots=True, kw_only=True)
+class Bucket:
+    """Bucket for transfer operations."""
+
+    transfer_type: TransferType
+    is_source: bool
+    dst_ranks: tuple[int, ...] | None = None
+    src_rank: int | None = None
+    group_key: tuple[int, tuple[int, ...]] | None = None
+    dtype: torch.dtype | None = None
+    device: torch.device | None = None
+    buffer: torch.Tensor | None = None
+    work: "torch.distributed.Work | None" = None
+    buffer_ready_event: torch.cuda.Event | None = None
+    offsets: list[tuple[int, int, BaseChunk, tuple[int, ...]]]
+
+    def __repr__(self) -> str:
+        """Return a concise representation for debugging."""
+        kind = "src" if self.is_source else "dst"
+        chunk_count = len(self.offsets)
+        return f"Bucket({kind}, chunks={chunk_count} src_rank={self.src_rank}→dst_ranks={self.dst_ranks})"

--- a/src/etha/tensor_bus/agent.py
+++ b/src/etha/tensor_bus/agent.py
@@ -17,7 +17,13 @@ from upath import UPath
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor.placement_types import Placement
 
-from etha.comm import get_m2m_map, m2m_communicate, map_to_chunk_ops
+from etha.comm import (
+    chunk_comm,
+    bucket_comm,
+    get_m2m_map,
+    map_to_chunk_ops,
+    chunk_to_bucket_ops,
+)
 
 from .utils import setup_cuda_rebuild_patch
 from .commands import Transfer, QueryStatus, RegisterPair, RegisterTensorBatch
@@ -310,10 +316,13 @@ class TensorBusAgent:
                     source_num_slicers=src_slicers_1,
                     target_num_slicers=tgt_slicers_1,
                 )
-
-            logger.info(f"Agent {self.rank}: Generated P2P maps for pair '{pair_name}'")
+            logger.info(
+                f"Agent {self.rank}: Generated P2P maps for pair '{pair_name}'. m2m_map_send: {m2m_map_send} m2m_map_recv: {m2m_map_recv}"
+            )
         else:
             logger.info(f"Agent {self.rank}: Skipping P2P map generation - missing or inconsistent mesh/placement info")
+
+        # Step 9: Create PairState
         if local_is_first:
             local_group = dist.new_group(local_ranks)
             remote_group = dist.new_group(remote_ranks)
@@ -321,7 +330,6 @@ class TensorBusAgent:
             remote_group = dist.new_group(remote_ranks)
             local_group = dist.new_group(local_ranks)
 
-        # Step 9: Create PairState
         state = PairState(
             pair_name=pair_name,
             local_name=local_name,
@@ -386,22 +394,24 @@ class TensorBusAgent:
 
         # Transfer tensors using chunk IR if available, otherwise fall back to simple send/recv
         pair_state = self.pairs[pair_name]
-
         if pair_state.send_chunks or pair_state.recv_chunks:
-            logger.info(f"Agent {self.rank}: Using optimized P2P transfer for pair '{pair_name}'")
-
             if transfer_type == "send":
+                buckets = pair_state.send_buckets
                 chunks = pair_state.send_chunks
             else:
+                buckets = pair_state.recv_buckets
                 chunks = pair_state.recv_chunks
 
-            # Execute all transfers in one batch using new unified pipeline
-            if chunks:
+            if buckets:
                 logger.info(
-                    f"Agent {self.rank}: Executing batch transfer with {len(chunks)} chunks "
-                    f"for {len(pair_state.tensors)} tensors"
+                    f"Agent {self.rank}: Executing bucketized transfer with {len(buckets)} buckets for pair '{pair_name}'"
                 )
-                m2m_communicate(chunks=chunks)
+                bucket_comm(buckets=buckets)
+            elif chunks:
+                logger.info(
+                    f"Agent {self.rank}: Executing chunk-based transfer with {len(chunks)} chunks for pair '{pair_name}'"
+                )
+                chunk_comm(chunks=chunks)
         else:
             # Fall back to simple send/recv without P2P optimization
             logger.info(
@@ -448,6 +458,7 @@ class TensorBusAgent:
         pair_name = msg.pair_name
         tensor_names = msg.tensor_names
         tensor_payloads = msg.tensor_payloads
+        bucket_size = msg.bucket_size
 
         if pair_name not in self.pairs:
             raise ValueError(f"RegisterTensorBatch for unknown pair: {pair_name}")
@@ -511,14 +522,28 @@ class TensorBusAgent:
                     target_dtype=target_dtype,
                 )
                 all_recv_chunks.extend(recv_chunks)
-
+        logger.debug(f"Agent {self.rank}: all send chunks: {all_send_chunks} all recv chunks: {all_recv_chunks}")
+        logger.info(
+            f"Agent {self.rank}: all send chunks: {len(all_send_chunks)} all recv chunks: {len(all_recv_chunks)}"
+        )
         # Store unified chunk lists directly on pair state
         pair_state.send_chunks = all_send_chunks
         pair_state.recv_chunks = all_recv_chunks
 
+        if bucket_size:
+            pair_state.send_buckets = chunk_to_bucket_ops(
+                chunks=all_send_chunks,
+                bucket_size=bucket_size,
+            )
+            pair_state.recv_buckets = chunk_to_bucket_ops(
+                chunks=all_recv_chunks,
+                bucket_size=bucket_size,
+            )
+            logger.info(
+                f"Agent {self.rank}: send buckets: {len(pair_state.send_buckets)} recv buckets: {len(pair_state.recv_buckets)}"
+            )
         logger.info(
             f"Agent {self.rank}: Completed batch registration of {len(tensor_names)} tensors for pair '{pair_name}': "
-            f"send ({len(all_send_chunks)} chunks), recv ({len(all_recv_chunks)} chunks)"
         )
 
     def _collect_mesh_placement_info(

--- a/src/etha/tensor_bus/client.py
+++ b/src/etha/tensor_bus/client.py
@@ -210,6 +210,7 @@ class TensorBusClient:
         pair_name: str,
         tensor_names: list[str],
         tensors: list[torch.Tensor],
+        bucket_size: int | None = None,
         blocking: bool = True,
         timeout: float = 30.0,
     ):
@@ -219,6 +220,7 @@ class TensorBusClient:
             pair_name: pair name
             tensor_names: list of tensor names
             tensors: list of tensors
+            bucket_size: optional bucket size in bytes for chunk bucketing
             blocking: whether to block until completion
             timeout: timeout in seconds
         """
@@ -229,7 +231,12 @@ class TensorBusClient:
 
         tensor_payloads = [ForkingPickler.dumps(tensor.detach()) for tensor in tensors]
 
-        msg = RegisterTensorBatch(pair_name=pair_name, tensor_names=tensor_names, tensor_payloads=tensor_payloads)
+        msg = RegisterTensorBatch(
+            pair_name=pair_name,
+            tensor_names=tensor_names,
+            tensor_payloads=tensor_payloads,
+            bucket_size=bucket_size,
+        )
 
         return self._execute_command_with_semaphore(
             msg, "register_tensor_batch", pair_name, blocking=blocking, timeout=timeout
@@ -364,18 +371,40 @@ class PairHandler:
         """
         return self.client.query_transfer_signal(self.pair_name, blocking=blocking, timeout=timeout)
 
-    def register_tensor(self, tensor_name: str, tensor: torch.Tensor, blocking: bool = False, timeout: float = 30.0):
+    def register_tensor(
+        self,
+        tensor_name: str,
+        tensor: torch.Tensor,
+        bucket_size: int | None = None,
+        blocking: bool = False,
+        timeout: float = 30.0,
+    ):
         """Register a tensor to the pair."""
         return self.client.register_tensor_batch(
-            pair_name=self.pair_name, tensor_names=[tensor_name], tensors=[tensor], blocking=blocking, timeout=timeout
+            pair_name=self.pair_name,
+            tensor_names=[tensor_name],
+            tensors=[tensor],
+            bucket_size=bucket_size,
+            blocking=blocking,
+            timeout=timeout,
         )
 
     def register_tensor_batch(
-        self, tensor_names: list[str], tensors: list[torch.Tensor], blocking: bool = False, timeout: float = 30.0
+        self,
+        tensor_names: list[str],
+        tensors: list[torch.Tensor],
+        bucket_size: int | None = None,
+        blocking: bool = False,
+        timeout: float = 30.0,
     ):
         """Register multiple tensors in batch."""
         return self.client.register_tensor_batch(
-            pair_name=self.pair_name, tensor_names=tensor_names, tensors=tensors, blocking=blocking, timeout=timeout
+            pair_name=self.pair_name,
+            tensor_names=tensor_names,
+            tensors=tensors,
+            bucket_size=bucket_size,
+            blocking=blocking,
+            timeout=timeout,
         )
 
     def close(self):

--- a/src/etha/tensor_bus/commands.py
+++ b/src/etha/tensor_bus/commands.py
@@ -36,6 +36,7 @@ class RegisterTensorBatch(BaseCommand):
     pair_name: str
     tensor_names: list[str]
     tensor_payloads: list[memoryview]
+    bucket_size: int | None = None
 
 
 class RegisterPair(BaseCommand):

--- a/src/etha/tensor_bus/pair_state.py
+++ b/src/etha/tensor_bus/pair_state.py
@@ -4,7 +4,7 @@ import torch
 import msgspec
 import torch.distributed as dist
 
-from etha.comm.ir import SourceChunk, TargetChunk
+from etha.comm.ir import Bucket, SourceChunk, TargetChunk
 
 
 class M2MMap(msgspec.Struct):
@@ -41,3 +41,6 @@ class PairState(msgspec.Struct):
     # Execution layer: Unified chunk lists (one pair per direction)
     send_chunks: list[SourceChunk | TargetChunk] | None = None  # Unified send chunks
     recv_chunks: list[SourceChunk | TargetChunk] | None = None  # Unified recv chunks
+
+    send_buckets: list[Bucket] | None = None
+    recv_buckets: list[Bucket] | None = None

--- a/tests/test_communication_cpu.py
+++ b/tests/test_communication_cpu.py
@@ -11,13 +11,15 @@ from torch.distributed._tensor import Shard, Replicate, DeviceMesh, distribute_t
 from torch.distributed.tensor.placement_types import _StridedShard
 
 from etha.comm import (
+    chunk_comm,
+    bucket_comm,
     get_m2m_map,
-    m2m_communicate,
     map_to_chunk_ops,
-    gather_broadcast_communicate,
+    chunk_to_bucket_ops,
+    gather_broadcast_comm,
 )
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
@@ -44,14 +46,15 @@ def run_test_communication(
     torch.manual_seed(0)
     shape = (64, 64)
     source_origin_tensor = torch.randn(shape, device=device)
-    target_origin_tensor = torch.randn(shape, device=device)
+    target_origin_tensor_chunk = torch.randn(shape, device=device)
+    target_origin_tensor_bucket = torch.randn(shape, device=device)
     is_in_source = rank < source_world_size
 
     source_dist_tensor = distribute_tensor(source_origin_tensor, source_mesh, source_specs)
     source_local_tensor = source_dist_tensor.to_local()
 
-    target_dist_tensor = distribute_tensor(target_origin_tensor, target_mesh, target_specs)
-    target_local_tensor = target_dist_tensor.to_local()
+    target_dist_tensor_chunk = distribute_tensor(target_origin_tensor_chunk, target_mesh, target_specs)
+    target_local_chunk = target_dist_tensor_chunk.to_local()
 
     logger.debug(f"[rank={rank}] Source mesh: {source_mesh.mesh}")
     logger.debug(f"[rank={rank}] Target mesh: {target_mesh.mesh}")
@@ -66,7 +69,8 @@ def run_test_communication(
         group=dist.group.WORLD,
         device=device,
     )
-
+    if rank == 0:
+        logger.info(f"Generated m2m map: {m2m_map}")
     # Step 2: Generate execution-ready chunks directly
     chunks = map_to_chunk_ops(
         m2m_map=m2m_map,
@@ -74,34 +78,48 @@ def run_test_communication(
         source_num_slicers=source_num_slicers,
         target_num_slicers=target_num_slicers,
         source_tensor=source_local_tensor,
-        target_tensor=target_local_tensor,
+        target_tensor=target_local_chunk,
     )
 
     if rank == 0:
         logger.info(f"Generated {len(chunks)} chunks")
 
     # Test M2M communication with unified chunks
-    m2m_communicate(chunks=chunks)
+    chunk_comm(chunks=chunks)
 
+    target_dist_tensor_bucket = distribute_tensor(target_origin_tensor_bucket, target_mesh, target_specs)
+    target_local_bucket = target_dist_tensor_bucket.to_local()
+    bucket_chunks = map_to_chunk_ops(
+        m2m_map=m2m_map,
+        rank=rank,
+        source_num_slicers=source_num_slicers,
+        target_num_slicers=target_num_slicers,
+        source_tensor=source_local_tensor,
+        target_tensor=target_local_bucket,
+    )
+    buckets = chunk_to_bucket_ops(
+        chunks=bucket_chunks,
+        bucket_size=256 * 1024,
+    )
+    logger.debug(f"[rank={rank}] Generated {len(buckets)} buckets")
+    bucket_comm(buckets=buckets)
+    logger.debug(f"[rank={rank}] Bucket communication completed")
     # Test Gather-Broadcast Method
-    gather_broadcast_result = gather_broadcast_communicate(
+    gather_broadcast_result = gather_broadcast_comm(
         target_mesh,
         target_specs,
         source_dist_tensor,
-        target_origin_tensor,
+        target_origin_tensor_chunk,
         source_world_size,
     )
     if not is_in_source:
-        full_m2m_result = target_dist_tensor.full_tensor()
-
-        assert torch.allclose(full_m2m_result, source_origin_tensor)
-        # Assert results are close (due to potential floating point differences in distributed ops)
-        if target_local_tensor is not None and gather_broadcast_result is not None:
-            assert torch.allclose(target_local_tensor, gather_broadcast_result.to_local())
-        else:
-            raise RuntimeError(
-                f"One result is None, the other is not. M2M: {target_local_tensor}, Gather-Broadcast: {gather_broadcast_result}"
-            )
+        chunk_result = target_dist_tensor_chunk.full_tensor()
+        bucket_result = target_dist_tensor_bucket.full_tensor()
+        assert torch.allclose(chunk_result, source_origin_tensor)
+        assert torch.allclose(bucket_result, source_origin_tensor)
+        if gather_broadcast_result is None:
+            raise RuntimeError("Gather-Broadcast result missing on target rank.")
+        assert torch.allclose(target_local_chunk, gather_broadcast_result.to_local())
 
     dist.destroy_process_group()
 

--- a/tests/test_communication_symmetric_mesh.py
+++ b/tests/test_communication_symmetric_mesh.py
@@ -10,8 +10,8 @@ import torch.distributed as dist
 from torch.distributed._tensor import Shard, DeviceMesh, distribute_tensor
 
 from etha.comm import (
+    chunk_comm,
     get_m2m_map,
-    m2m_communicate,
     map_to_chunk_ops,
 )
 
@@ -105,15 +105,15 @@ def run_test_communication(
 
     logger.info(f"[rank={rank}] Generated {len(chunks)} chunks")
 
-    logger.info(f"[rank={rank}] About to start m2m_communicate")
+    logger.info(f"[rank={rank}] About to start chunk_comm")
 
     for chunk in chunks:
         logger.info(f"[rank={rank}] Chunk: {chunk}")
 
     # Execute communication
-    m2m_communicate(chunks=chunks)
+    chunk_comm(chunks=chunks)
 
-    logger.info(f"[rank={rank}] Finished m2m_communicate")
+    logger.info(f"[rank={rank}] Finished chunk_comm")
 
     # Verify results for receiver side
     if not is_in_mesh_a:


### PR DESCRIPTION
# Test results

<img width="1291" height="82" alt="image" src="https://github.com/user-attachments/assets/2bc3739c-dcec-43c8-876f-90ed8244dffd" />

# Bench results
<img width="1061" height="660" alt="image" src="https://github.com/user-attachments/assets/4d9ac3d4-ad70-43ec-81dc-ff34540e9f03" />
<img width="1055" height="665" alt="image" src="https://github.com/user-attachments/assets/47e87169-17c8-4788-9e9a-d98618a6fafc" />
<img width="1062" height="657" alt="image" src="https://github.com/user-attachments/assets/4ffd20aa-0a93-4f5f-b0a5-ccaafe52827e" />
<img width="1056" height="653" alt="image" src="https://github.com/user-attachments/assets/bee147db-c06b-4ad9-9c6d-55e1d02bdf30" />
<img width="1051" height="653" alt="image" src="https://github.com/user-attachments/assets/b8aa0e50-cdc3-44af-831c-42877a6da35d" />
<img width="1056" height="659" alt="image" src="https://github.com/user-attachments/assets/e5762f3f-07bf-4d16-b042-c1675a8af1e2" />
<img width="1056" height="648" alt="image" src="https://github.com/user-attachments/assets/8c8034d4-93bc-4abd-803e-521037981053" />
<img width="1050" height="662" alt="image" src="https://github.com/user-attachments/assets/56c7a86d-e038-4640-9d39-fe9f406bba6e" />
<img width="1058" height="655" alt="image" src="https://github.com/user-attachments/assets/a42979c5-c853-46a0-8f3d-24686e804c65" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bucket-based communication support and configurable bucket size for tensor registration; benchmark plots now include bucket throughput.
  * Startup script now logs centralized files and prints a confirmation when processes start.

* **Refactor**
  * Core communication APIs and execution model renamed/reorganized for clearer chunk vs. bucket paths.
  * Profiling configuration extended with memory-snapshot control.

* **Other**
  * Standardized distributed strategy env var and increased registration timeouts for robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->