### PR TITLE
fix: get p2p map when all are replicate

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -53,7 +53,7 @@ results/
 │   └── mesh_01_4_2_1_1_1_1_4_2/
 │       └── shape_(4096, 4096)/
 │           └── rank_0/
-│               ├── m2m_comm/
+│               ├── chunk_comm/
 │               │   └── iteration_3/
 │               │       ├── rank0_trace.pt.trace.json
 │               │       └── rank0_memory_snapshot.pickle

--- a/bench/benchmark.py
+++ b/bench/benchmark.py
@@ -162,7 +162,7 @@ def benchmark_single_shape(
         m2m_profiling_spec = ProfilingSpec(
             enable_profiling=True,
             dump_folder=UPath(profiling_config["dump_folder"]),
-            save_traces_folder=UPath(f"traces/{mesh_info}/shape_{shape[0]}/rank_{rank}/m2m_comm"),
+            save_traces_folder=UPath(f"traces/{mesh_info}/shape_{shape[0]}/rank_{rank}/chunk_comm"),
             profile_freq=profiling_config["profile_freq"],
             warmup_steps=profiling_config["warmup_steps"],
             active_steps=profiling_config["active_steps"],
@@ -460,8 +460,8 @@ def generate_result_plot(
     # Plot all methods including ideal bandwidth
     plot_configs = [
         ("ideal_bandwidth_gb_s", "Ideal (RDMA+NVLink)", "--", "green", None),
-        ("m2m_effective_throughput_gb_s", "M2M Effective", "o", "blue", 8),
-        ("bucket_effective_throughput_gb_s", "Bucket Effective", "s", "purple", 7),
+        ("m2m_effective_throughput_gb_s", "Chunk-Based", "o", "blue", 8),
+        ("bucket_effective_throughput_gb_s", "Bucket-Based", "s", "purple", 7),
         ("baseline_effective_throughput_gb_s", "Gather-Broadcast", "X", "orange", 8),
     ]
 

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -11,7 +11,7 @@ from attr import dataclass
 from upath import UPath
 
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.INFO,
     format="[%(asctime)s] [Worker %(process)d] [%(levelname)s] %(message)s",
     datefmt="%H:%M:%S",
 )

--- a/src/etha/comm/bucket_execution.py
+++ b/src/etha/comm/bucket_execution.py
@@ -26,7 +26,7 @@ def _prepare_source_bucket(bucket: Bucket) -> None:
 
     for entry in bucket.entries:
         chunk = entry.chunk
-        _prepare_chunk(chunk)
+        _prepare_chunk(chunk, contiguous=False)
         flat = chunk.buffer.view(-1)
         bucket.buffer.narrow(0, entry.offset, entry.numel).copy_(flat, non_blocking=True)
         chunk.buffer = None
@@ -104,7 +104,9 @@ def _finalize_bucket(bucket: Bucket) -> list[torch.cuda.Event]:
 
     if not bucket.is_source:
         for entry in bucket.entries:
-            events.append(_finalize_chunk(entry.chunk))
+            event = _finalize_chunk(entry.chunk)
+            if event is not None:
+                events.append(event)
 
     bucket.buffer = None
 

--- a/src/etha/comm/bucket_execution.py
+++ b/src/etha/comm/bucket_execution.py
@@ -96,21 +96,16 @@ def _is_bucket_complete(bucket: Bucket) -> bool:
     return bucket.work.is_completed()
 
 
-def _finalize_bucket(bucket: Bucket) -> list[torch.cuda.Event]:
-    events: list[torch.cuda.Event] = []
+def _finalize_bucket(bucket: Bucket) -> None:
     if bucket.work is not None:
         bucket.work.wait()
         bucket.work = None
 
     if not bucket.is_source:
         for entry in bucket.entries:
-            event = _finalize_chunk(entry.chunk)
-            if event is not None:
-                events.append(event)
+            _finalize_chunk(entry.chunk)
 
     bucket.buffer = None
-
-    return events
 
 
 def execute_bucket_pipeline(
@@ -137,7 +132,6 @@ def execute_bucket_pipeline(
                 return True
         return False
 
-    events: list[torch.cuda.Event] = []
     while _has_work():
         for state in key_states.values():
             candidate: deque = state["candidate"]
@@ -166,7 +160,5 @@ def execute_bucket_pipeline(
                 if not _is_bucket_complete(in_flight[0]):
                     break
                 logger.debug(f"[rank={rank}] Bucket execution: Finalizing bucket {in_flight[0]}")
-                events.extend(_finalize_bucket(in_flight.popleft()))
-
-    for event in events:
-        event.wait()
+                _finalize_bucket(in_flight.popleft())
+    torch.cuda.synchronize()

--- a/src/etha/comm/chunk_execution.py
+++ b/src/etha/comm/chunk_execution.py
@@ -7,13 +7,16 @@ from .ir import SourceChunk, TargetChunk, TransferType
 from .utils import get_or_create_process_group
 
 
-def _prepare_chunk(chunk: SourceChunk | TargetChunk) -> None:
+def _prepare_chunk(chunk: SourceChunk | TargetChunk, contiguous: bool = True) -> None:
     match chunk.transfer_type:
         case TransferType.SELF_COPY:
             if isinstance(chunk, TargetChunk):
                 chunk.buffer = chunk.tensor[chunk.src_slice_tuples]
         case _:
-            chunk.buffer = chunk.tensor[chunk.slice_tuples].contiguous()
+            if contiguous:
+                chunk.buffer = chunk.tensor[chunk.slice_tuples].contiguous()
+            else:
+                chunk.buffer = chunk.tensor[chunk.slice_tuples]
     if isinstance(chunk, SourceChunk) and chunk.target_dtype != chunk.buffer.dtype:
         chunk.buffer = chunk.buffer.to(chunk.target_dtype)
 
@@ -43,9 +46,10 @@ def _finalize_chunk(chunk: SourceChunk | TargetChunk) -> torch.cuda.Event:
 
     chunk.buffer = None
 
-    event = torch.cuda.Event()
-    event.record()
-
+    event = None
+    if chunk.tensor.device.type == "cuda":
+        event = torch.cuda.Event()
+        event.record()
     return event
 
 
@@ -56,4 +60,5 @@ def execute_chunk_simple(
         _prepare_chunk(chunk)
         _launch_chunk(chunk)
         event = _finalize_chunk(chunk)
-        event.wait()
+        if event is not None:
+            event.wait()

--- a/src/etha/comm/chunk_execution.py
+++ b/src/etha/comm/chunk_execution.py
@@ -36,7 +36,7 @@ def _launch_chunk(chunk: SourceChunk | TargetChunk) -> None:
                 chunk.work = dist.irecv(chunk.buffer, src=chunk.src_rank)
 
 
-def _finalize_chunk(chunk: SourceChunk | TargetChunk) -> torch.cuda.Event:
+def _finalize_chunk(chunk: SourceChunk | TargetChunk) -> None:
     if chunk.work is not None:
         chunk.work.wait()
         chunk.work = None
@@ -46,12 +46,6 @@ def _finalize_chunk(chunk: SourceChunk | TargetChunk) -> torch.cuda.Event:
 
     chunk.buffer = None
 
-    event = None
-    if chunk.tensor.device.type == "cuda":
-        event = torch.cuda.Event()
-        event.record()
-    return event
-
 
 def execute_chunk_simple(
     chunks: list[SourceChunk | TargetChunk],
@@ -59,6 +53,5 @@ def execute_chunk_simple(
     for chunk in chunks:
         _prepare_chunk(chunk)
         _launch_chunk(chunk)
-        event = _finalize_chunk(chunk)
-        if event is not None:
-            event.wait()
+        _finalize_chunk(chunk)
+        torch.cuda.synchronize()

--- a/src/etha/comm/get_m2m_map.py
+++ b/src/etha/comm/get_m2m_map.py
@@ -21,7 +21,7 @@ def _get_tensor_ndim(placements: tuple[Placement, ...]) -> int:
     return (
         max(
             (placement.dim for placement in placements if isinstance(placement, Shard)),
-            default=-1,
+            default=0,
         )
         + 1
     )

--- a/tests/test_communication_cpu.py
+++ b/tests/test_communication_cpu.py
@@ -127,6 +127,7 @@ def run_test_communication(
 @pytest.mark.parametrize(
     "source_mesh_shape, target_mesh_shape",
     [
+        ((4, 1, 1, 1), (4, 1, 1, 1)),
         ((2, 2, 1, 1), (2, 1, 1, 2)),
         ((2, 2, 1, 1), (2, 1, 2, 1)),
         ((2, 1, 2, 1), (2, 1, 1, 2)),


### PR DESCRIPTION
- remove duplicate copy in prepare bucket
- make test pass in cpu-only device

# Test Results
<img width="1183" height="235" alt="image" src="https://github.com/user-attachments/assets/62aa2d50-b63d-4fe8-8a36-7de2ceb719bf" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary GPU/CPU synchronization and streamlined finalization behavior.
  * Preserved non-contiguous buffer views when appropriate.
  * Fixed edge-case handling in shard/placement dimension calculations.

* **Tests**
  * Added coverage for identical source and target mesh configurations.

* **Chores**
  * Renamed benchmark outputs/labels to chunk-based naming and lowered benchmark logging verbosity.

* **Documentation**
  * Updated benchmark README to reflect chunk-based output naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->