### PR TITLE
docs: surface bench plots, link them, and highlight zero-copy path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ __pycache__
 *.egg-info
 .ipynb_checkpoints
 
-results
+/results
 
 dev/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Etha
 
-> M × N tensor transfer between PyTorch process groups.
+> M-to-N tensor transfer between PyTorch process groups.
 > Named after the [Sub-Etha](https://hitchhikers.fandom.com/wiki/Sub-Etha).
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -19,7 +19,7 @@ Two compounding properties keep the data path tight:
 - **Zero-copy** worker → agent handoff via CUDA IPC handles. The agent
   runs NCCL send / recv directly against the worker's registered tensor,
   with no host roundtrip and no staging buffer on either side.
-- **Zero-duplicate** wire traffic from the M × N M2M plan. Each source
+- **Zero-duplicate** wire traffic from the M-to-N M2M plan. Each source
   rank sends only the shards it owns straight to the target ranks that
   need them — no intermediate rank ever materializes a full copy of the
   tensor. (A naive gather-then-broadcast baseline, by contrast,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Etha
 
-> Distributed P2P tensor transfer for PyTorch.
+> M × N tensor transfer between PyTorch process groups.
 > Named after the [Sub-Etha](https://hitchhikers.fandom.com/wiki/Sub-Etha).
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -14,10 +14,16 @@ It plans the cross-process-group **resharding** (`DeviceMesh` + `Placement`
 on each side) once per pair, then specializes that plan per batch into
 NCCL send / recv ops bucketed for throughput.
 
-The worker → agent handoff uses CUDA IPC handles, so transfers are
-**zero-copy** end-to-end and **zero-duplicate**: the agent runs NCCL send /
-recv directly against the worker's registered tensor — no host roundtrip
-and no staging buffers on either side.
+Two compounding properties keep the data path tight:
+
+- **Zero-copy** worker → agent handoff via CUDA IPC handles. The agent
+  runs NCCL send / recv directly against the worker's registered tensor,
+  with no host roundtrip and no staging buffer on either side.
+- **Zero-duplicate** wire traffic from the M × N M2M plan. Each source
+  rank sends only the shards it owns straight to the target ranks that
+  need them — no intermediate rank ever materializes a full copy of the
+  tensor. (A naive gather-then-broadcast baseline, by contrast,
+  reconstitutes the whole tensor on every rank before redistributing.)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ It plans the cross-process-group **resharding** (`DeviceMesh` + `Placement`
 on each side) once per pair, then specializes that plan per batch into
 NCCL send / recv ops bucketed for throughput.
 
+The worker → agent handoff uses CUDA IPC handles, so transfers are
+**zero-copy** end-to-end and **zero-duplicate**: the agent runs NCCL send /
+recv directly against the worker's registered tensor — no host roundtrip
+and no staging buffers on either side.
+
 ## Architecture
 
 ```
@@ -112,7 +117,16 @@ handler.close()
 A complete runnable example that transfers a Qwen3 model between two separate
 `torchrun` groups lives in
 [`prototyping/distributed_model_transfer/`](prototyping/distributed_model_transfer/).
-Benchmarks are under [`bench/`](bench/).
+
+## Benchmarks
+
+Throughput of M2M (Etha) vs. a gather-broadcast baseline across 8 different
+`(source_mesh → target_mesh)` resharding configurations on 16 GPUs:
+
+![Mesh 4 example: (2,2,2,1) → (1,1,4,2)](bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2.png)
+
+Full result matrix, profiler / memory-snapshot setup, and the KVStore
+microbenchmark are in [bench/README.md](bench/README.md).
 
 ## Repository layout
 

--- a/bench/results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1.png
+++ b/bench/results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfaf456c7a6edf29dcaeaf98ea2cdc5e0b5c066f22d23f8d52b485db993f0dd8
+size 168131

--- a/bench/results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2.png
+++ b/bench/results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f2ee71b1e51f4b0f5e515c0da0a29218b7550e0319f0c2525ad8cd778b89e0f
+size 179990

--- a/bench/results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1.png
+++ b/bench/results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78854adb36b18919e3a052f8459d9a5ac0b041bf77296178018857aebb722767
+size 171501

--- a/bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2.png
+++ b/bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b94dfd53245f56871f757ba8e8088ef10291c9d96656fa9dbf4d1c91e5f2b71b
+size 180567

--- a/bench/results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1.png
+++ b/bench/results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96fd5db36ab0080c79ab34016e29679b49a1583ef72a803c1ca8ff67c5e88094
+size 178757

--- a/bench/results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4.png
+++ b/bench/results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5879c1e8a60d799d67453ddd7da22533920c0c713c9041e017a04109be80242
+size 180242

--- a/bench/results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8.png
+++ b/bench/results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b738bca975d6254179ae1c9a56365004ec6d5be17ebb15b07f77383b59c206ef
+size 182947

--- a/bench/results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4.png
+++ b/bench/results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:871cf085cd29f198c01731db56c5523c0c3222c9e059e3e844e3e252fb89ae5b
+size 178883


### PR DESCRIPTION
## What did you do
Two related README polishes after #84 merged:

**1. Make the benchmark plots actually visible.**
The 8 throughput PNGs in `bench/results/` were never on GitHub because `.gitignore`'s bare `results` rule was excluding `bench/results/` along with the root run-output dir. Scope the rule to `/results` so only the root one is ignored, then commit the plots through git LFS (the `.gitattributes` LFS rule was already there but a no-op until now). Reference one of them from the main README as a teaser and link to `bench/README.md` for the full result matrix and profiler setup.

**2. Spell out the zero-copy / zero-duplicate property.**
The worker → agent handoff goes through CUDA IPC handles, and the agent issues NCCL send / recv directly against the worker's registered tensor — there's no host roundtrip and no staging buffer on either side. That was implicit from the architecture before; this PR makes it explicit in the opening paragraph so anyone landing on the repo sees it without having to read source.

## New test cases
N/A — docs / repo-asset only.

## Test results
N/A.

## Other comments
Total LFS upload is 1.4 MB across 8 PNGs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cmriat/Etha/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->