### PR TITLE
docs: drop the cherry-picked benchmark plot from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,16 +123,8 @@ handler.close()
 A complete runnable example that transfers a Qwen3 model between two separate
 `torchrun` groups lives in
 [`prototyping/distributed_model_transfer/`](prototyping/distributed_model_transfer/).
-
-## Benchmarks
-
-Throughput of M2M (Etha) vs. a gather-broadcast baseline across 8 different
-`(source_mesh → target_mesh)` resharding configurations on 16 GPUs:
-
-![Mesh 4 example: (2,2,2,1) → (1,1,4,2)](bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2.png)
-
-Full result matrix, profiler / memory-snapshot setup, and the KVStore
-microbenchmark are in [bench/README.md](bench/README.md).
+Throughput comparisons against a gather-broadcast baseline across 8 mesh
+configurations are in [`bench/`](bench/).
 
 ## Repository layout
 


### PR DESCRIPTION
## What did you do
Remove the Benchmarks section that was added in #85 and replace it with a one-liner pointing at `bench/`.

Embedding one of the 8 throughput plots in the main README was arbitrary, and including all of them would bloat the file. The PNGs themselves stay LFS-tracked and remain linked from `bench/README.md`, which is the right place for the full result matrix.

## New test cases
N/A — docs only.

## Test results
N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the Benchmarks section in the README by removing detailed content and referencing standalone benchmark resources for throughput comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cmriat/Etha/pull/86)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->