### PR TITLE
refactor: drop TorchTCPStore.add, use local counter in chat_client

### DIFF
--- a/examples/vllm_weight_sync/chat_client.py
+++ b/examples/vllm_weight_sync/chat_client.py
@@ -1,9 +1,9 @@
 """Stress chat against the vLLM OpenAI server, gated by the control store.
 
 Reads `vllm_ready` / `vllm_version` to skip requests during sync and tag
-each reply with the live weight version. Atomically bumps `chat_count`
-after every successful completion — trainer rank 0 watches that counter
-to gate the next sync round, so the demo runs at the chat's pace.
+each reply with the live weight version. Bumps `chat_count` after every
+successful completion — trainer rank 0 watches that counter to gate the
+next sync round, so the demo runs at the chat's pace.
 """
 
 import os
@@ -51,6 +51,8 @@ def main() -> None:
     logger.info("vllm server is up at %s:%d", CONFIG.vllm_http_host, CONFIG.vllm_http_port)
 
     round_idx = 0
+    chat_count = 0
+    store.set("chat_count", "0")
     while CONFIG.chat_rounds == 0 or round_idx < CONFIG.chat_rounds:
         ready = store.get("vllm_ready")
         if ready != b"1":
@@ -76,8 +78,9 @@ def main() -> None:
                     prompt,
                     resp.choices[0].text,
                 )
-                new_count = store.add("chat_count", 1)
-                logger.debug("chat_count -> %d", new_count)
+                chat_count += 1
+                store.set("chat_count", str(chat_count))
+                logger.debug("chat_count -> %d", chat_count)
             except Exception:
                 logger.exception("chat round=%d prompt=%r failed", round_idx, prompt)
         time.sleep(CONFIG.chat_interval)

--- a/src/etha/kvstore/tcp.py
+++ b/src/etha/kvstore/tcp.py
@@ -74,16 +74,6 @@ class TorchTCPStore(KVStore):
         self._store.set(prefixed, value)
         self._known_keys.add(key)
 
-    def add(self, key: str, value: int, *, component: str | None = None) -> int:
-        """Atomically increment integer key by value, returning new value.
-
-        Creates the key with value=0 first if it doesn't exist.
-        """
-        prefixed = self._prefixed(key, component)
-        new_value = self._store.add(prefixed, value)
-        self._known_keys.add(key)
-        return new_value
-
     def get(self, key: str, *, component: str | None = None) -> bytes | None:
         """Get value for a key."""
         prefixed = self._prefixed(key, component)


### PR DESCRIPTION
## What did you do

`TorchTCPStore.add` was a subclass-only method with a single caller —
`examples/vllm_weight_sync/chat_client.py` bumping `chat_count`. That
counter has one writer (the chat process) and one reader (trainer rank
0), so atomic increment was never load-bearing. Replace with a local
counter + `store.set`, drop the method, and stop dragging an unmatched
API on a single backend.

The base `KVStore` ABC and the etcd backend never declared `add`, so
this removes the asymmetry rather than papering over it with stub
implementations and tests for a behaviour nothing actually needs.

## New test cases

None — pure removal.

## Test results

Smoke-tested locally on 8×H20Z: `pixi run -e vllm vllm_weight_sync`
ran 3 sync rounds end-to-end. Trainer exited rc=0, `chat_count`
gating reached 3/6/9 as expected, chat replies coherent at v=1 and
v=2.

## Other comments

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated counter management logic in the stress-chat demo to properly track and advance increments using explicit local counters initialized and synchronized with the control store.

* **Refactor**
  * Removed atomic counter increment functionality from the key-value store infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cmriat/Etha/pull/92)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->