### PR TITLE
docs: add docs site badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 > Named after the [Sub-Etha](https://hitchhikers.fandom.com/wiki/Sub-Etha).
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/github/actions/workflow/status/cmriat/Etha/docs.yml?branch=main&label=docs)](https://cmriat.github.io/Etha/)
 
 Etha is a tensor transfer library for PyTorch distributed jobs that need to
 move tensors between two independently-launched process groups — for example,


### PR DESCRIPTION
## What did you do

Adds a single shields.io badge to the README that:
- shows the latest \`docs.yml\` workflow build status on \`main\`
- links to the GitHub Pages docs site at https://cmriat.github.io/Etha/

\`\`\`markdown
[![Docs](https://img.shields.io/github/actions/workflow/status/cmriat/Etha/docs.yml?branch=main&label=docs)](https://cmriat.github.io/Etha/)
\`\`\`

Split out from #94 to keep that PR scoped to docs infra. Should land **after** #94 — until \`docs.yml\` exists on \`main\` and Pages is enabled, the badge renders \"no status\" and the link 404s.

## New test cases

N/A — README only.

## Test results

N/A.

## Other comments

Depends on #94.