### PR TITLE
docs: sharpen project positioning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,37 @@
 # Etha
 
-> M-to-N tensor transfer between PyTorch process groups.
+> Cross-process-group DTensor redistribute — any (mesh, placement) → any (mesh, placement).
 > Named after the [Sub-Etha](https://hitchhikers.fandom.com/wiki/Sub-Etha).
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/github/actions/workflow/status/cmriat/Etha/docs.yml?branch=main&label=docs)](https://cmriat.github.io/Etha/)
 
-Etha is a tensor transfer library for PyTorch distributed jobs that need to
-move tensors between two independently-launched process groups — for example,
-shipping model weights from a training cluster to an inference cluster in a
-disaggregated RL setup.
+Etha redistributes a tensor described as `(DeviceMesh, Placement)` on one
+PyTorch process group into a different `(DeviceMesh, Placement)` on a second,
+independently-launched process group — the same redistribution `DTensor` does
+in-process, generalized to two unrelated jobs.
 
-It plans the cross-process-group **resharding** (`DeviceMesh` + `Placement`
-on each side) once per pair, then specializes that plan per batch into
-NCCL send / recv ops bucketed for throughput.
+The canonical use case: shipping model weights from a training cluster to an
+inference cluster in a disaggregated RL setup, where the two sides were
+launched separately and run different parallelism configurations.
 
-Two compounding properties keep the data path tight:
+Four properties define the surface:
 
-- **Zero-copy** worker → agent handoff via CUDA IPC handles. The agent
-  runs NCCL send / recv directly against the worker's registered tensor,
-  with no host roundtrip and no staging buffer on either side.
-- **Zero-duplicate** wire traffic from the M-to-N M2M plan. Each source
-  rank sends only the shards it owns straight to the target ranks that
-  need them — no intermediate rank ever materializes a full copy of the
-  tensor. (A naive gather-then-broadcast baseline, by contrast,
-  reconstitutes the whole tensor on every rank before redistributing.)
+- **PyTorch-native.** Source and target layouts are PyTorch's own
+  `DeviceMesh` + `Placement` — the same primitives `DTensor` uses in-process.
+  No Etha-specific tensor wrapper, no parallel layout DSL to learn.
+- **Zero-copy.** Worker → agent handoff is via CUDA IPC handles. The agent
+  runs NCCL send / recv directly against the worker's registered tensor —
+  no host roundtrip, no staging buffer on either side.
+- **Zero-duplicate.** The M-to-N M2M plan ships each shard exactly once
+  from its owner to the ranks that need it; no intermediate rank ever
+  materializes a full copy of the tensor. (A naive gather-then-broadcast
+  baseline, by contrast, reconstitutes the whole tensor on every rank
+  before redistributing.)
+- **Low-intrusion.** The host ↔ agent split lets Etha drop into existing
+  training / inference code as a library — you instantiate a
+  `TensorBusClient` and hand it tensors. No model wrappers, no
+  restructuring of your distributed init, no framework to adopt.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Etha
 
-> Cross-process-group DTensor redistribute — any (mesh, placement) → any (mesh, placement).
+> M-to-N DTensor redistribute across PyTorch process groups — any (mesh, placement) → any (mesh, placement).
 > Named after the [Sub-Etha](https://hitchhikers.fandom.com/wiki/Sub-Etha).
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -23,11 +23,11 @@ Four properties define the surface:
 - **Zero-copy.** Worker → agent handoff is via CUDA IPC handles. The agent
   runs NCCL send / recv directly against the worker's registered tensor —
   no host roundtrip, no staging buffer on either side.
-- **Zero-duplicate.** The M-to-N M2M plan ships each shard exactly once
-  from its owner to the ranks that need it; no intermediate rank ever
-  materializes a full copy of the tensor. (A naive gather-then-broadcast
-  baseline, by contrast, reconstitutes the whole tensor on every rank
-  before redistributing.)
+- **M-to-N, zero-duplicate.** Source ranks send the shards they own
+  directly to the target ranks that need them — no intermediate rank
+  ever materializes a full copy of the tensor. (A naive
+  gather-then-broadcast baseline, by contrast, reconstitutes the whole
+  tensor on every rank before redistributing.)
 - **Low-intrusion.** The host ↔ agent split lets Etha drop into existing
   training / inference code as a library — you instantiate a
   `TensorBusClient` and hand it tensors. No model wrappers, no

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Etha
 
-> Cross-process-group DTensor redistribute — any (mesh, placement) → any (mesh, placement).
+> M-to-N DTensor redistribute across PyTorch process groups — any (mesh, placement) → any (mesh, placement).
 
 Etha redistributes a tensor described as `(DeviceMesh, Placement)` on one
 PyTorch process group into a different `(DeviceMesh, Placement)` on a second,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,15 @@
 # Etha
 
-> M-to-N tensor transfer between PyTorch process groups.
+> Cross-process-group DTensor redistribute — any (mesh, placement) → any (mesh, placement).
 
-Etha is a tensor transfer library for PyTorch distributed jobs that need to
-move tensors between two independently-launched process groups — for example,
-shipping model weights from a training cluster to an inference cluster in a
-disaggregated RL setup.
+Etha redistributes a tensor described as `(DeviceMesh, Placement)` on one
+PyTorch process group into a different `(DeviceMesh, Placement)` on a second,
+independently-launched process group — the same redistribution `DTensor` does
+in-process, generalized to two unrelated jobs.
 
-It plans the cross-process-group **resharding** (`DeviceMesh` + `Placement`
-on each side) once per pair, then specializes that plan per batch into
-NCCL send / recv ops bucketed for throughput.
+The canonical use case: shipping model weights from a training cluster to an
+inference cluster in a disaggregated RL setup, where the two sides were
+launched separately and run different parallelism configurations.
 
 ```{toctree}
 :caption: Design


### PR DESCRIPTION
## What did you do

Reframes Etha's positioning in the README and docs landing page to anchor it to the PyTorch primitive it actually generalizes (\`DTensor.redistribute\`) instead of the generic \"tensor transfer\" framing.

Changes:

- **Tagline**: \`M-to-N tensor transfer between PyTorch process groups\` → \`Cross-process-group DTensor redistribute — any (mesh, placement) → any (mesh, placement)\`. The \"cross-process-group\" qualifier carves out the niche relative to in-process \`DTensor.redistribute\`.
- **Intro paragraph**: lead with the redistribute framing (\`(DeviceMesh, Placement)\` → \`(DeviceMesh, Placement)\` across two independently-launched jobs), then the disaggregated-RL weight sync as a concrete instance instead of the headline.
- **Properties: Two → Four.** Adds two that were implicit before:
  - **PyTorch-native**: layouts are \`DeviceMesh\` + \`Placement\` directly, no wrapper / DSL to learn.
  - **Low-intrusion**: the host ↔ agent split makes Etha a library you call, not a framework you adopt — no model wrappers, no distributed-init rewrite.

\`docs/index.md\` mirrors the README tagline + intro (it does not carry the properties list).

## New test cases

N/A — docs-only.

## Test results

N/A.

## Other comments

Pure prose change; no code, no build, no API surface affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed README and introductory documentation to clarify Etha's cross-process-group DTensor redistribution capabilities between independently-launched PyTorch distributed jobs across different device mesh and placement configurations.
  * Enhanced descriptions of core features including PyTorch-native layouts, CUDA IPC zero-copy transfer, zero-duplicate shard movement, and lightweight client interface requiring no framework restructuring or additional wrappers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cmriat/Etha/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->