### PR TITLE
feat(comm): reject Partial placement in get_m2m_map

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Four properties define the surface:
   `TensorBusClient` and hand it tensors. No model wrappers, no
   restructuring of your distributed init, no framework to adopt.
 
+> **Supported placements:** `Shard` and `Replicate`. `Partial` is rejected
+> with `NotImplementedError` — redistribute it to `Replicate` or `Shard` on
+> the source mesh before handing the DTensor to Etha.
+
 ## Architecture
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,12 @@ The canonical use case: shipping model weights from a training cluster to an
 inference cluster in a disaggregated RL setup, where the two sides were
 launched separately and run different parallelism configurations.
 
+:::{note}
+Supported placements are currently `Shard` and `Replicate`. `Partial` is
+rejected with `NotImplementedError` — redistribute it to `Replicate` or
+`Shard` on the source mesh before handing the DTensor to Etha.
+:::
+
 ```{toctree}
 :caption: Design
 :maxdepth: 2

--- a/src/etha/comm/get_m2m_map.py
+++ b/src/etha/comm/get_m2m_map.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import torch
 import torch.distributed as dist
 from torch.distributed._tensor import Shard, DeviceMesh, distribute_tensor
-from torch.distributed.tensor.placement_types import Placement
+from torch.distributed.tensor.placement_types import Partial, Placement
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,25 @@ def get_m2m_map(
     group: dist.ProcessGroup,
     device: str = "cpu",
 ) -> tuple[dict[int, dict[tuple, list[tuple[int, tuple]]]], list[int], list[int]]:
-    """Get P2P communication map for tensor redistribution."""
+    """Get P2P communication map for tensor redistribution.
+
+    Only ``Shard`` and ``Replicate`` placements are supported. ``Partial`` is
+    rejected because the map is built by encoding ``rank`` + ``coord`` into a
+    middle tensor and shipping it via ``DTensor.full_tensor()``; for ``Partial``
+    that triggers an all-reduce which sums the encoded values across ranks and
+    corrupts the map.
+
+    Raises:
+        NotImplementedError: If any of ``source_placements`` or
+            ``target_placements`` contains a ``Partial``.
+    """
+    for placements, side in ((source_placements, "source"), (target_placements, "target")):
+        if any(isinstance(p, Partial) for p in placements):
+            raise NotImplementedError(
+                f"Partial placement is not supported (found in {side}_placements={placements}). "
+                "Etha currently supports only Shard and Replicate; redistribute Partial to "
+                "Replicate or Shard on the source mesh before handing the DTensor to Etha."
+            )
     rank = dist.get_rank()
     target_mesh_ranks = target_mesh.mesh.flatten().tolist()
     source_mesh_ranks = source_mesh.mesh.flatten().tolist()

--- a/src/etha/tensor_bus/client.py
+++ b/src/etha/tensor_bus/client.py
@@ -200,7 +200,10 @@ class TensorBusClient:
             remote_name: Name of remote peer
             expected_world_size: Number of ranks for local peer
             device_mesh: Local device mesh configuration
-            placements: Local tensor placement strategy
+            placements: Local tensor placement strategy. Only ``Shard`` and
+                ``Replicate`` are supported; ``Partial`` is rejected at M2M
+                map construction time (redistribute it to ``Replicate`` or
+                ``Shard`` on the source mesh first).
 
         Blocks until:
             - Agent registers to TCPStore


### PR DESCRIPTION
## What did you do

Fail loud on `Partial` placement instead of silently corrupting the M2M map.

`get_m2m_map` builds the rank-to-rank plan by encoding `(rank, coord)` into a middle tensor and shipping it via `DTensor.full_tensor()`. For `Shard` / `Replicate`, `full_tensor()` reduces to an all-gather (or local copy) and the encoding survives. For `Partial`, `full_tensor()` triggers an all-reduce that **sums the encoded values across ranks**, corrupting the map — the resulting transfer would copy garbage with no error raised.

This PR:

- Detects `Partial` in either `source_placements` or `target_placements` at the top of `get_m2m_map` and raises `NotImplementedError` with a message pointing at the workaround (redistribute to `Replicate` / `Shard` on the source mesh first).
- Documents the supported placement set (`Shard`, `Replicate`) in:
  - `get_m2m_map` docstring (with the why)
  - `TensorBusClient.init_pair` docstring (the user-facing API)
  - `README.md`
  - `docs/index.md`

Adding actual `Partial` support (e.g. eager `Partial → Replicate` on source mesh before entering the M2M flow) is deferred to a follow-up.

## New test cases

None — this is a guard rail change with no new code path beyond a single `raise`.

## Test results

- `ruff format` + `ruff check` clean (also enforced by pre-commit hook on this commit).
- `pixi run -e docs docs` builds successfully (same pre-existing kvstore inline-emphasis warning, unrelated).
- `from etha.comm.get_m2m_map import get_m2m_map` imports clean.

## Other comments

n/a