### PR TITLE
feat(comm): support source-Partial placements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ logs
 trace_processor
 
 docs/_build/
+
+.claude/

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Four properties define the surface:
   `TensorBusClient` and hand it tensors. No model wrappers, no
   restructuring of your distributed init, no framework to adopt.
 
-> **Supported placements:** `Shard` and `Replicate`. `Partial` is rejected
-> with `NotImplementedError` — redistribute it to `Replicate` or `Shard` on
-> the source mesh before handing the DTensor to Etha.
+> **Placements:** source supports `Shard` / `Replicate` / `Partial`
+> (collapsed to `Replicate` via a source-side all-reduce before send).
+> Target `Partial` is rejected.
 
 ## Architecture
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -93,42 +93,65 @@ profile_plot(snapshot)
 ---
 
 # Test results
-Test on 16 GPUs with 2 nodes.
 
-source mesh placement: [Replicate(), Replicate(), Shard(0), Shard(1)]
-target mesh placement: [Replicate(), _StridedShard(1, split_factor=2), Replicate(), Shard(1)]
+Tested on 16 GPUs across 2 nodes. Each mesh combination is run under three
+source placements; target placement is fixed to
+`[Replicate, Replicate, StridedShard(0, split=k), Shard(0)]`
+where `k = target_mesh[3]`.
 
-## Mesh Configuration 1
-* 1, 1, 4, 2 -> 4, 2, 1, 1
-![Mesh 1](./results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1.png)
+| Config | Source placement |
+|---|---|
+| `no_partial`   | `[Replicate, Shard(0), Replicate, Shard(1)]` |
+| `replicate_dp` | `[Replicate, Replicate, Replicate, Shard(1)]` |
+| `partial_dp`   | `[Replicate, Partial("sum"), Replicate, Shard(1)]` |
 
-## Mesh Configuration 2
-* 8, 1, 1, 1 -> 1, 2, 2, 2
-![Mesh 2](./results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2.png)
+## Mesh 1 — (1, 1, 4, 2) → (4, 2, 1, 1)
 
-## Mesh Configuration 3
-* 1, 2, 4, 1 -> 8, 1, 1, 1
-![Mesh 3](./results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1.png)
+| no_partial | replicate_dp | partial_dp |
+|---|---|---|
+| ![](./results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1_no_partial.png) | ![](./results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1_replicate_dp.png) | ![](./results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1_partial_dp.png) |
 
-## Mesh Configuration 4
-* 2, 2, 2, 1 -> 1, 1, 4, 2
-![Mesh 4](./results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2.png)
+## Mesh 2 — (8, 1, 1, 1) → (1, 2, 2, 2)
 
-## Mesh Configuration 5
-* 2, 4, 1, 1 -> 1, 2, 4, 1
-![Mesh 5](./results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1.png)
+| no_partial | replicate_dp | partial_dp |
+|---|---|---|
+| ![](./results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2_no_partial.png) | ![](./results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2_replicate_dp.png) | ![](./results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2_partial_dp.png) |
 
-## Mesh Configuration 6
-* 4, 1, 1, 2 -> 2, 1, 1, 4
-![Mesh 6](./results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4.png)
+## Mesh 3 — (1, 2, 4, 1) → (8, 1, 1, 1)
 
-## Mesh Configuration 7
-* 4, 1, 2, 1 -> 1, 1, 1, 8
-![Mesh 7](./results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8.png)
+| no_partial | replicate_dp | partial_dp |
+|---|---|---|
+| ![](./results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1_no_partial.png) | ![](./results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1_replicate_dp.png) | ![](./results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1_partial_dp.png) |
 
-## Mesh Configuration 8
-* 4, 2, 1, 1 -> 1, 1, 2, 4
-![Mesh 8](./results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4.png)
+## Mesh 4 — (2, 2, 2, 1) → (1, 1, 4, 2)
+
+| no_partial | replicate_dp | partial_dp |
+|---|---|---|
+| ![](./results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2_no_partial.png) | ![](./results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2_replicate_dp.png) | ![](./results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2_partial_dp.png) |
+
+## Mesh 5 — (2, 4, 1, 1) → (1, 2, 4, 1)
+
+| no_partial | replicate_dp | partial_dp |
+|---|---|---|
+| ![](./results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1_no_partial.png) | ![](./results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1_replicate_dp.png) | ![](./results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1_partial_dp.png) |
+
+## Mesh 6 — (4, 1, 1, 2) → (2, 1, 1, 4)
+
+| no_partial | replicate_dp | partial_dp |
+|---|---|---|
+| ![](./results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4_no_partial.png) | ![](./results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4_replicate_dp.png) | ![](./results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4_partial_dp.png) |
+
+## Mesh 7 — (4, 1, 2, 1) → (1, 1, 1, 8)
+
+| no_partial | replicate_dp | partial_dp |
+|---|---|---|
+| ![](./results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8_no_partial.png) | ![](./results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8_replicate_dp.png) | ![](./results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8_partial_dp.png) |
+
+## Mesh 8 — (4, 2, 1, 1) → (1, 1, 2, 4)
+
+| no_partial | replicate_dp | partial_dp |
+|---|---|---|
+| ![](./results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4_no_partial.png) | ![](./results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4_replicate_dp.png) | ![](./results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4_partial_dp.png) |
 
 ---
 

--- a/bench/results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1.png
+++ b/bench/results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:adecc8d78128f3274bf2d3872c034147ea619310747025803e177379381da376
-size 194627

--- a/bench/results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1_no_partial.png
+++ b/bench/results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1_no_partial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:249e61ee1021f40e66c6b9e42587082be6cfa50ae119d216fd272d5131735362
+size 193392

--- a/bench/results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1_partial_dp.png
+++ b/bench/results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1_partial_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec6cc5c98f5fa20e2508f44d7cb399fb260a1492283f4b2f591da944dce57e99
+size 201313

--- a/bench/results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1_replicate_dp.png
+++ b/bench/results/throughput_benchmark_mesh_01_1_1_4_2_4_2_1_1_replicate_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3647d0d49997ba813c7edfe67ea83d0e2ca93914fd02ef29d41bfe27e0e2b22c
+size 195415

--- a/bench/results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2.png
+++ b/bench/results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:339d186670c1ca25e00a49bc8101e6cbee7fceee32d21ffe93de6da9327c3c8b
-size 203087

--- a/bench/results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2_no_partial.png
+++ b/bench/results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2_no_partial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1034075f545baca86cfe81254135da71181dce79b5fd39bdf548170b38534ed
+size 206785

--- a/bench/results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2_partial_dp.png
+++ b/bench/results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2_partial_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5412cda237ca872f56f438c8a298c8e32081d469e3aaf3a274c30aaed39d4d9
+size 213902

--- a/bench/results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2_replicate_dp.png
+++ b/bench/results/throughput_benchmark_mesh_02_8_1_1_1_1_2_2_2_replicate_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df91559a5dcaf3c770a2d2d573acdd94fd653de214f64201d65c13f7455c8f6f
+size 207649

--- a/bench/results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1.png
+++ b/bench/results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c4fb9e40f4e687526565dabd435bd46bb45afacf02c21ea45bcfa1d123d1b35
-size 191870

--- a/bench/results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1_no_partial.png
+++ b/bench/results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1_no_partial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:977eddbd1edc7b63a55f811629f33779b9ebc6de5bed2034bd6a7d0dfe715db7
+size 196514

--- a/bench/results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1_partial_dp.png
+++ b/bench/results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1_partial_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bb0b49ffb796c82e18b6dc54a2150b48309b9ca39e8718e9d06cf9dc67f1585
+size 200414

--- a/bench/results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1_replicate_dp.png
+++ b/bench/results/throughput_benchmark_mesh_03_1_2_4_1_8_1_1_1_replicate_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40b547ff81915d6272d47e4462e9a30d01b4ed3d9fb0f0aa38251f686e12aa9d
+size 192548

--- a/bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2.png
+++ b/bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:538fcc03a53f67f2a9cd645d3710562395dc53eb7cdf1b7c26276615c043a795
-size 200324

--- a/bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2_no_partial.png
+++ b/bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2_no_partial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3cfcb2d2139851c7ec967edb1cd097ff0f599ff2b00fc55faa5a7fbac9efd57
+size 205125

--- a/bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2_partial_dp.png
+++ b/bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2_partial_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43cbc5764d176eeb9b5f1e170a7a560502d7eae93fd7e5b3c3929166d2e3bfee
+size 225164

--- a/bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2_replicate_dp.png
+++ b/bench/results/throughput_benchmark_mesh_04_2_2_2_1_1_1_4_2_replicate_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8097e4707bd950e8160483493ed25f88743fa824566c819c9d5c29b2668289cd
+size 218379

--- a/bench/results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1.png
+++ b/bench/results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7e10beb76d6ba57750847f27face63c1fdfb0af70cf6a277c6f8f5b581223d9
-size 200691

--- a/bench/results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1_no_partial.png
+++ b/bench/results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1_no_partial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aee09cf0130485f66c2776ee39f1fd8c0bdea4cfc8b33a88a0062b8c4df28f4
+size 206230

--- a/bench/results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1_partial_dp.png
+++ b/bench/results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1_partial_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cce7b7c69e4893b0398b45fb26bbc77c8946d1452592e310aea6e19b9807720
+size 212948

--- a/bench/results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1_replicate_dp.png
+++ b/bench/results/throughput_benchmark_mesh_05_2_4_1_1_1_2_4_1_replicate_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55dc17196c0514a49a2155a4c0ec82fed6b4e27ab79606824cc48af6112618cf
+size 206354

--- a/bench/results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4.png
+++ b/bench/results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c153a3250bfc9e98f9bbe5bf96dfe878bc2e1795206bca92797d5b43f205e02
-size 204033

--- a/bench/results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4_no_partial.png
+++ b/bench/results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4_no_partial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5197d1f39117187efcfc39e322822dc69ebd1b186bf2f5f4027badbd8ef0b5a4
+size 208789

--- a/bench/results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4_partial_dp.png
+++ b/bench/results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4_partial_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39d8985348e1185a5eaa00f33654eca78908636881e08bf3a5cff30e1555a6c1
+size 216882

--- a/bench/results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4_replicate_dp.png
+++ b/bench/results/throughput_benchmark_mesh_06_4_1_1_2_2_1_1_4_replicate_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb79ccf917dc71795bf495b33c5b35f49c0eae179d698784be75c581cbd55341
+size 209828

--- a/bench/results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8.png
+++ b/bench/results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:577ab6d020fd7267cf9d8bbb25ba0e2c16936ad3b45109c48bbf27c0b80927b6
-size 212795

--- a/bench/results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8_no_partial.png
+++ b/bench/results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8_no_partial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:275b8c49ea743ebe4850c7a0016a977a3683e7eb32ec17d331879c8d88f1f700
+size 216659

--- a/bench/results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8_partial_dp.png
+++ b/bench/results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8_partial_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e104afb11e2b7de5f2c7959217002c8ceb915db626ad89e865f927341b406f7
+size 224657

--- a/bench/results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8_replicate_dp.png
+++ b/bench/results/throughput_benchmark_mesh_07_4_1_2_1_1_1_1_8_replicate_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f66194de251b30c4275e729e1a58e78feedf433c4ed29318a4f9cf4cfe1cf37
+size 216808

--- a/bench/results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4.png
+++ b/bench/results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec7436618fef23e5062eac433575572cbbb64cf4543772a45369663ad986c440
-size 199783

--- a/bench/results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4_no_partial.png
+++ b/bench/results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4_no_partial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c809c87a4d3a2446b15d05b696a4a4b16b641b578eb91cd16d5797a9752ac75
+size 220057

--- a/bench/results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4_partial_dp.png
+++ b/bench/results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4_partial_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4178074d2fec5f75227ec35635a23426e0c795d7b0996ae18048ac172e9bc92
+size 224651

--- a/bench/results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4_replicate_dp.png
+++ b/bench/results/throughput_benchmark_mesh_08_4_2_1_1_1_1_2_4_replicate_dp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7861b8ff3c38610bc7203f8750e252f70086cb4164aaf5f131b9b5a55e24f27d
+size 216804

--- a/bench/transfer_benchmark.py
+++ b/bench/transfer_benchmark.py
@@ -15,7 +15,7 @@ import torch.distributed as dist
 from upath import UPath
 from utils import ProfilingSpec, dump_memory_snapshot, maybe_enable_profiling
 from torch.distributed._tensor import Shard, Replicate, DeviceMesh, distribute_tensor
-from torch.distributed.tensor.placement_types import _StridedShard
+from torch.distributed.tensor.placement_types import Partial, _StridedShard
 
 from etha.comm import (
     chunk_comm,
@@ -25,6 +25,8 @@ from etha.comm import (
     chunk_to_bucket_ops,
     gather_broadcast_comm,
 )
+from etha.pg_utils import get_or_create_process_group
+from etha.comm.utils import enumerate_partial_subgroup_ranks
 
 # Hardware bandwidth parameters (GB/s)
 RDMA_SEND_BANDWIDTH_GB_S = 50.0
@@ -111,15 +113,16 @@ def calculate_ideal_bandwidth(
 
 
 def benchmark_single_shape(
-    origin_tensors: list[torch.Tensor],  # List of origin tensors (batch)
+    origin_tensors: list[torch.Tensor],  # Singleton list of the baseline reference tensor
     source_dist_tensors: list,  # List of source distributed tensors
     target_local_tensors: list,  # List of target local tensors
+    num_tensors: int,  # Logical batch size (origin_tensors holds only index 0 to save memory)
     shape: tuple,
     chunks: list,  # All chunks from all tensors (extended)
     buckets: list,
     current_source_mesh: DeviceMesh,
     current_target_mesh: DeviceMesh,
-    source_specs: list,  # noqa
+    source_specs: list,
     target_specs: list,
     source_world_size: int,
     device: str,
@@ -130,6 +133,7 @@ def benchmark_single_shape(
     gpus_per_node: int,
     profiling_config: dict | None = None,
     mesh_info: str = "",
+    has_partial: bool = False,
 ):
     """Benchmark M2M vs Gather-Broadcast for a batch of tensors.
 
@@ -143,9 +147,8 @@ def benchmark_single_shape(
     Returns:
         dict with benchmark results if rank == 0, None otherwise.
     """
-    # Calculate total size of all tensors in batch
-    total_tensor_size_bytes = sum(t.nelement() * t.element_size() for t in origin_tensors)
-    num_tensors = len(origin_tensors)
+    # Calculate total size of all tensors in batch (per-tensor size × num_tensors).
+    total_tensor_size_bytes = origin_tensors[0].nelement() * origin_tensors[0].element_size() * num_tensors
 
     # Check if we need to profile this shape
     should_profile = profiling_config is not None and shape in profiling_config["profile_shapes"]
@@ -255,30 +258,25 @@ def benchmark_single_shape(
     torch.cuda.synchronize()
     bucket_time = start_event.elapsed_time(end_event) / 1000.0 / profile_iter  # ms -> s
 
-    # Gather-Broadcast method warmup (only test first tensor as reference)
+    # Gather-Broadcast method warmup (only test first tensor as reference).
+    # For Partial source: user manually redistributes to Replicate first (inside
+    # the timed loop so the reduce cost is counted), then calls gather_broadcast.
+    def _baseline_iter():
+        if source_dist_tensors:
+            src_dt = source_dist_tensors[0]
+            if has_partial:
+                src_dt = _pre_reduce_to_replicate(src_dt, current_source_mesh, source_specs)
+            return gather_broadcast_comm(
+                current_target_mesh, target_specs, src_dt, origin_tensors[0], source_world_size
+            )
+        return gather_broadcast_comm(current_target_mesh, target_specs, None, origin_tensors[0], source_world_size)
+
     dist.barrier()
     bc_result = None
     for _ in range(warmup_iter):
-        if source_dist_tensors:
-            # Source ranks pass their distributed tensor
-            bc_result = gather_broadcast_comm(
-                current_target_mesh,
-                target_specs,
-                source_dist_tensors[0],  # Use first tensor as reference
-                origin_tensors[0],
-                source_world_size,
-            )
-        else:
-            # Target ranks still need to participate in the collective
-            bc_result = gather_broadcast_comm(
-                current_target_mesh,
-                target_specs,
-                None,  # No source tensor for target ranks
-                origin_tensors[0],
-                source_world_size,
-            )
+        bc_result = _baseline_iter()
 
-    # Verify correctness for first tensor (M2M_communicate modifies target tensors in-place)
+    # Verify correctness for first tensor (M2M modifies target tensors in-place).
     if target_local_tensors and target_local_tensors[0] is not None and bc_result is not None:
         if not torch.allclose(target_local_tensors[0], bc_result.to_local()):
             print(f"[Rank {rank}] M2M result shape: {target_local_tensors[0].shape}")
@@ -311,22 +309,7 @@ def benchmark_single_shape(
                 for step in range(gb_profiling_spec.profile_freq):
                     profiler.step()
                     for _ in range(10):
-                        if source_dist_tensors:
-                            gather_broadcast_comm(
-                                current_target_mesh,
-                                target_specs,
-                                source_dist_tensors[0],
-                                origin_tensors[0],
-                                source_world_size,
-                            )
-                        else:
-                            gather_broadcast_comm(
-                                current_target_mesh,
-                                target_specs,
-                                None,
-                                origin_tensors[0],
-                                source_world_size,
-                            )
+                        _baseline_iter()
 
                     # Additional memory snapshot if requested
                     if gb_profiling_spec.enable_memory_snapshot and step == gb_profiling_spec.warmup_steps + 1:
@@ -347,22 +330,7 @@ def benchmark_single_shape(
 
     start_event.record()
     for _ in range(profile_iter):
-        if source_dist_tensors:
-            gather_broadcast_comm(
-                current_target_mesh,
-                target_specs,
-                source_dist_tensors[0],
-                origin_tensors[0],
-                source_world_size,
-            )
-        else:
-            gather_broadcast_comm(
-                current_target_mesh,
-                target_specs,
-                None,
-                origin_tensors[0],
-                source_world_size,
-            )
+        _baseline_iter()
     end_event.record()
 
     torch.cuda.synchronize()
@@ -415,15 +383,50 @@ def benchmark_single_shape(
 def _placements_to_str(placements: list) -> str:
     parts = []
     for placement in placements:
-        if isinstance(placement, Replicate):
-            parts.append("Replicate")
-        elif isinstance(placement, Shard):
-            parts.append(f"Shard({placement.dim})")
-        elif isinstance(placement, _StridedShard):
-            parts.append(f"StridedShard({placement.dim}, split={placement.split_factor})")
-        else:
-            parts.append(str(placement))
+        # _StridedShard subclasses Shard; match its case first.
+        match placement:
+            case Replicate():
+                parts.append("Replicate")
+            case _StridedShard():
+                parts.append(f"StridedShard({placement.dim}, split={placement.split_factor})")
+            case Shard():
+                parts.append(f"Shard({placement.dim})")
+            case Partial():
+                parts.append(f"Partial({placement.reduce_op})")
+            case _:
+                parts.append(str(placement))
     return "[" + ", ".join(parts) + "]"
+
+
+def _build_source_partial_groups(
+    source_mesh: DeviceMesh,
+    source_placements: list,
+    this_rank: int,
+    source_ranks: list[int],
+) -> list[tuple[dist.ProcessGroup, str]] | None:
+    """Mirror of agent._create_partial_groups for benchmark use."""
+    if not any(isinstance(p, Partial) for p in source_placements):
+        return None
+    full_set = set(source_ranks)
+    full_source_group = get_or_create_process_group(source_ranks)
+    my_groups: list[tuple[dist.ProcessGroup, str]] = []
+    for mesh_dim_idx, p in enumerate(source_placements):
+        if not isinstance(p, Partial):
+            continue
+        for sub_ranks in enumerate_partial_subgroup_ranks(source_mesh.mesh, mesh_dim_idx):
+            if set(sub_ranks) == full_set:
+                group = full_source_group
+            else:
+                group = get_or_create_process_group(sub_ranks)
+            if this_rank in sub_ranks:
+                my_groups.append((group, p.reduce_op))
+    return my_groups or None
+
+
+def _pre_reduce_to_replicate(source_dt, source_mesh: DeviceMesh, source_placements: list):
+    """The baseline's manual Partial→Replicate step (timed inline for fairness)."""
+    effective = [Replicate() if isinstance(p, Partial) else p for p in source_placements]
+    return source_dt.redistribute(source_mesh, effective)
 
 
 def generate_result_plot(
@@ -434,24 +437,31 @@ def generate_result_plot(
     num_tensors_per_batch: int,
     source_specs: list,
     target_specs: list,
+    config_name: str = "",
+    has_partial: bool = False,
 ):
-    """Generate and save throughput comparison plot."""
+    """Generate and save throughput comparison plot.
+
+    Partial configs draw the baseline line as "Pre-reduce + Gather-Broadcast"
+    since the reduce cost is timed inside the baseline loop.
+    """
     df = pd.DataFrame(results)
 
     plt.style.use("seaborn-v0_8-whitegrid")
     fig, ax = plt.subplots(1, 1, figsize=(8, 5))
 
-    # Plot all methods including ideal bandwidth
+    baseline_label = "Pre-reduce + Gather-Broadcast" if has_partial else "Gather-Broadcast"
+    chunk_label = "Chunk-Based (Partial in-pipeline)" if has_partial else "Chunk-Based"
+
     plot_configs = [
         ("ideal_bandwidth_gb_s", "Ideal (RDMA+NVLink)", "--", "green", None),
-        ("m2m_effective_throughput_gb_s", "Chunk-Based", "o", "blue", 8),
+        ("m2m_effective_throughput_gb_s", chunk_label, "o", "blue", 8),
         ("bucket_effective_throughput_gb_s", "Bucket-Based", "s", "purple", 7),
-        ("baseline_effective_throughput_gb_s", "Gather-Broadcast", "X", "orange", 8),
+        ("baseline_effective_throughput_gb_s", baseline_label, "X", "orange", 8),
     ]
 
     for y_col, label, marker, color, markersize in plot_configs:
         if marker == "--":
-            # Dashed line for ideal bandwidth
             ax.plot(df["tensor_size_mb"], df[y_col], linestyle="--", color=color, linewidth=2, label=label, alpha=0.7)
         else:
             sns.lineplot(
@@ -465,8 +475,9 @@ def generate_result_plot(
                 color=color,
             )
 
+    title_extra = f" [{config_name}]" if config_name else ""
     ax.set_title(
-        f"Batch Transfer Throughput ({num_tensors_per_batch} tensors)\n"
+        f"Batch Transfer Throughput ({num_tensors_per_batch} tensors){title_extra}\n"
         f"Mesh: {source_mesh_shape} → {target_mesh_shape}\n"
         f"source_specs={_placements_to_str(source_specs)}\n"
         f"target_specs={_placements_to_str(target_specs)}",
@@ -480,10 +491,10 @@ def generate_result_plot(
 
     plt.tight_layout()
 
-    # Generate clean filename
     src = "_".join(map(str, source_mesh_shape))
     tgt = "_".join(map(str, target_mesh_shape))
-    fig_path = RESULTS_DIR / f"throughput_benchmark_mesh_{mesh_idx + 1:02d}_{src}_{tgt}.png"
+    suffix = f"_{config_name}" if config_name else ""
+    fig_path = RESULTS_DIR / f"throughput_benchmark_mesh_{mesh_idx + 1:02d}_{src}_{tgt}{suffix}.png"
 
     fig.savefig(fig_path, dpi=300)
     print(f"✅ Plot saved: {fig_path}")
@@ -544,216 +555,250 @@ def main():
                 if rank == 0:
                     print(f"Warning: Failed to enable memory recording: {e}")
 
-    # BENCHMARKING PARAMETERS
-    warmup_iter = 3
-    profile_iter = 20
-    gpus_per_node = int(os.environ.get("LOCAL_WORLD_SIZE", 8))  # Default to 8 GPUs per node
+    # SMOKE_TEST: shrink the sweep to a single-node 8-GPU run for quick
+    # verification of the Partial path. Toggle off for the full benchmark.
+    SMOKE_TEST = os.environ.get("ETHA_BENCH_SMOKE", "0") == "1"
 
-    # Reduced shape list: each shape tests 5 tensors in batch
-    tensor_shapes = [
-        (512, 512),
-        (1024, 1024),
-        (2048, 2048),
-        (4096, 4096),
-        (8192, 8192),
-        (12288, 12288),
-        (16384, 16384),
-        (20480, 20480),
-        (24576, 24576),
+    warmup_iter = 1 if SMOKE_TEST else 3
+    profile_iter = 3 if SMOKE_TEST else 20
+    gpus_per_node = int(os.environ.get("LOCAL_WORLD_SIZE", 8))
+
+    if SMOKE_TEST:
+        # 4 source + 4 target = 8 GPUs; Partial on mesh dim 1 (size 2) is non-trivial.
+        tensor_shapes = [(2048, 2048)]
+        num_tensors_per_batch = 2
+        mesh_combinations = [
+            ((1, 2, 1, 2), (1, 1, 2, 2)),
+        ]
+    else:
+        tensor_shapes = [
+            (512, 512),
+            (1024, 1024),
+            (2048, 2048),
+            (4096, 4096),
+            (8192, 8192),
+            (12288, 12288),
+            (16384, 16384),
+            (20480, 20480),
+            (24576, 24576),
+        ]
+        num_tensors_per_batch = 25
+        # 8 source + 8 target = 16 GPUs total
+        mesh_combinations = [
+            ((1, 1, 4, 2), (4, 2, 1, 1)),
+            ((8, 1, 1, 1), (1, 2, 2, 2)),
+            ((1, 2, 4, 1), (8, 1, 1, 1)),
+            ((2, 2, 2, 1), (1, 1, 4, 2)),
+            ((2, 4, 1, 1), (1, 2, 4, 1)),
+            ((4, 1, 1, 2), (2, 1, 1, 4)),
+            ((4, 1, 2, 1), (1, 1, 1, 8)),
+            ((4, 2, 1, 1), (1, 1, 2, 4)),
+        ]
+
+    print(f"Total {len(mesh_combinations)} mesh combinations (smoke={SMOKE_TEST})")
+
+    BENCH_CONFIGS: list[tuple[str, list]] = [
+        ("no_partial", [Replicate(), Shard(0), Replicate(), Shard(dim=1)]),
+        ("replicate_dp", [Replicate(), Replicate(), Replicate(), Shard(dim=1)]),
+        ("partial_dp", [Replicate(), Partial("sum"), Replicate(), Shard(dim=1)]),
     ]
 
-    num_tensors_per_batch = 25  # Number of tensors to send in each batch
-
-    # Mesh combinations: source_mesh_shape -> target_mesh_shape (total 16 devices)
-    # Each dimension must be power of 2: 1, 2, 4, 8
-    mesh_combinations = [
-        ((1, 1, 4, 2), (4, 2, 1, 1)),
-        ((8, 1, 1, 1), (1, 2, 2, 2)),
-        ((1, 2, 4, 1), (8, 1, 1, 1)),
-        ((2, 2, 2, 1), (1, 1, 4, 2)),
-        ((2, 4, 1, 1), (1, 2, 4, 1)),
-        ((4, 1, 1, 2), (2, 1, 1, 4)),
-        ((4, 1, 2, 1), (1, 1, 1, 8)),
-        ((4, 2, 1, 1), (1, 1, 2, 4)),
-    ]
-
-    print(f"Total {len(mesh_combinations)} different 16-device mesh combinations")
-
-    source_specs = [Replicate(), Shard(0), Replicate(), Shard(dim=1)]
-
-    # Run benchmark for all mesh combinations and generate plots
     print("Starting batch testing for all mesh combinations...")
-    print(f"Total {len(mesh_combinations)} mesh combinations to test")
+    print(f"Total {len(mesh_combinations)} mesh combinations × {len(BENCH_CONFIGS)} configs to test")
 
-    all_results = {}  # Store results for all mesh combinations
+    all_results = {}
 
-    for mesh_idx, (source_mesh_shape, target_mesh_shape) in enumerate(mesh_combinations):
-        # Create target_specs dynamically based on target_mesh_shape
-        # split_factor should equal the size of mesh dimension 2 (the Shard(0) dimension)
-        split_factor = target_mesh_shape[3]
-        target_specs = [Replicate(), Replicate(), _StridedShard(0, split_factor=split_factor), Shard(0)]
-        print(f"\n{'=' * 80}")
-        print(f"Testing mesh combination {mesh_idx + 1}/{len(mesh_combinations)}:")
-        print(f"Source mesh: {source_mesh_shape} -> Target mesh: {target_mesh_shape}")
-        print(f"{'=' * 80}")
+    for config_name, source_specs in BENCH_CONFIGS:
+        has_partial = any(isinstance(p, Partial) for p in source_specs)
+        print(f"\n{'#' * 80}")
+        print(f"# Config: {config_name} (Partial source: {has_partial})")
+        print(f"# source_specs = {_placements_to_str(source_specs)}")
+        print(f"{'#' * 80}")
 
-        # Setup current mesh
-        source_world_size = math.prod(source_mesh_shape)
-        target_world_size = math.prod(target_mesh_shape)
+        for mesh_idx, (source_mesh_shape, target_mesh_shape) in enumerate(mesh_combinations):
+            # Create target_specs dynamically based on target_mesh_shape
+            # split_factor should equal the size of mesh dimension 2 (the Shard(0) dimension)
+            split_factor = target_mesh_shape[3]
+            target_specs = [Replicate(), Replicate(), _StridedShard(0, split_factor=split_factor), Shard(0)]
+            print(f"\n{'=' * 80}")
+            print(f"Testing mesh combination {mesh_idx + 1}/{len(mesh_combinations)}:")
+            print(f"Source mesh: {source_mesh_shape} -> Target mesh: {target_mesh_shape}")
+            print(f"{'=' * 80}")
 
-        print(
-            f"Source mesh size: {source_world_size} devices, "
-            f"Target mesh size: {target_world_size} devices, "
-            f"Total: {source_world_size + target_world_size} devices"
-        )
+            # Setup current mesh
+            source_world_size = math.prod(source_mesh_shape)
+            target_world_size = math.prod(target_mesh_shape)
 
-        # Create mesh
-        current_source_mesh = DeviceMesh(device, torch.arange(source_world_size).view(source_mesh_shape))
-        current_target_mesh = DeviceMesh(
-            device, torch.arange(source_world_size, source_world_size + target_world_size).view(target_mesh_shape)
-        )
+            print(
+                f"Source mesh size: {source_world_size} devices, "
+                f"Target mesh size: {target_world_size} devices, "
+                f"Total: {source_world_size + target_world_size} devices"
+            )
 
-        # Run benchmark for current mesh
-        current_results = []
-        if device == "cuda":
-            torch.cuda.synchronize()
-        dist.barrier()
-        start_time = time.perf_counter()
-        m2m_map, source_num_slicers, target_num_slicers = get_m2m_map(
-            source_mesh=current_source_mesh,
-            source_placements=source_specs,
-            target_mesh=current_target_mesh,
-            target_placements=target_specs,
-            group=dist.group.WORLD,
-            device=device,
-        )
-        map_time = (time.perf_counter() - start_time) / profile_iter
-        if rank == 0:
-            print(f"get_m2m_map time: {map_time}")
-        for shape in tensor_shapes:
-            print(f"  Benchmarking batch of {num_tensors_per_batch} tensors with shape: {shape}...")
+            # Create mesh
+            current_source_mesh = DeviceMesh(device, torch.arange(source_world_size).view(source_mesh_shape))
+            current_target_mesh = DeviceMesh(
+                device, torch.arange(source_world_size, source_world_size + target_world_size).view(target_mesh_shape)
+            )
 
-            is_in_source = rank < source_world_size
+            source_ranks_list = list(range(source_world_size))
+            source_partial_groups = _build_source_partial_groups(
+                current_source_mesh, source_specs, rank, source_ranks_list
+            )
 
-            # Generate batch of tensors
-            origin_tensors = []
-            source_dist_tensors = []
-            target_local_tensors = []
-
-            for i in range(num_tensors_per_batch):
-                torch.manual_seed(i)  # Different seed for each tensor
-                origin_tensor = torch.randn(shape, device=device)
-                origin_tensors.append(origin_tensor)
-
-                if is_in_source:
-                    source_dist_tensor = distribute_tensor(origin_tensor, current_source_mesh, source_specs)
-                    source_dist_tensors.append(source_dist_tensor)
-                else:
-                    target_dist_tensor = distribute_tensor(origin_tensor, current_target_mesh, target_specs)
-                    target_local_tensors.append(target_dist_tensor.to_local())
-
-            # Generate chunks for all tensors and extend into one list
+            # Run benchmark for current mesh
+            current_results = []
             if device == "cuda":
                 torch.cuda.synchronize()
             dist.barrier()
-
             start_time = time.perf_counter()
-
-            all_chunks = []
-            for i in range(num_tensors_per_batch):
-                if is_in_source:
-                    source_local_tensor = source_dist_tensors[i].to_local()
-                    target_local_tensor = None
-                else:
-                    source_local_tensor = None
-                    target_local_tensor = target_local_tensors[i]
-
-                chunks = map_to_chunk_ops(
-                    m2m_map=m2m_map,
-                    rank=rank,
-                    source_num_slicers=source_num_slicers,
-                    target_num_slicers=target_num_slicers,
-                    source_tensor=source_local_tensor,
-                    target_tensor=target_local_tensor,
-                )
-                all_chunks.extend(chunks)
-
-            all_buckets = chunk_to_bucket_ops(
-                chunks=all_chunks,
-                bucket_size=BUCKET_SIZE_BYTES,
+            m2m_map, source_num_slicers, target_num_slicers, _ = get_m2m_map(
+                source_mesh=current_source_mesh,
+                source_placements=source_specs,
+                target_mesh=current_target_mesh,
+                target_placements=target_specs,
+                group=dist.group.WORLD,
+                device=device,
             )
-
-            ir_gen_time = (time.perf_counter() - start_time) / profile_iter
+            map_time = (time.perf_counter() - start_time) / profile_iter
             if rank == 0:
-                print(f"    IR generation time: {ir_gen_time:.6f}s")
-                print(
-                    f"    Generated {len(all_chunks)} chunks total ({len(all_chunks) // num_tensors_per_batch} per tensor)"
+                print(f"get_m2m_map time: {map_time}")
+            for shape in tensor_shapes:
+                print(f"  Benchmarking batch of {num_tensors_per_batch} tensors with shape: {shape}...")
+
+                is_in_source = rank < source_world_size
+
+                # Only origin_tensors[0] is needed downstream (baseline reference);
+                # keeping all 25 full-shape tensors on every rank blows past 100+ GiB
+                # for shape=(24576, 24576).
+                origin_tensors = []
+                source_dist_tensors = []
+                target_local_tensors = []
+
+                for i in range(num_tensors_per_batch):
+                    torch.manual_seed(i)  # Different seed for each tensor
+                    origin_tensor = torch.randn(shape, device=device)
+
+                    if is_in_source:
+                        source_dist_tensor = distribute_tensor(origin_tensor, current_source_mesh, source_specs)
+                        source_dist_tensors.append(source_dist_tensor)
+                    else:
+                        target_dist_tensor = distribute_tensor(origin_tensor, current_target_mesh, target_specs)
+                        target_local_tensors.append(target_dist_tensor.to_local())
+
+                    if i == 0:
+                        origin_tensors.append(origin_tensor)
+                    # else: drop the full reference so PyTorch can free it.
+
+                # Generate chunks for all tensors and extend into one list
+                if device == "cuda":
+                    torch.cuda.synchronize()
+                dist.barrier()
+
+                start_time = time.perf_counter()
+
+                all_chunks = []
+                for i in range(num_tensors_per_batch):
+                    if is_in_source:
+                        source_local_tensor = source_dist_tensors[i].to_local()
+                        target_local_tensor = None
+                    else:
+                        source_local_tensor = None
+                        target_local_tensor = target_local_tensors[i]
+
+                    chunks = map_to_chunk_ops(
+                        m2m_map=m2m_map,
+                        rank=rank,
+                        source_num_slicers=source_num_slicers,
+                        target_num_slicers=target_num_slicers,
+                        source_tensor=source_local_tensor,
+                        target_tensor=target_local_tensor,
+                        source_partial_groups=source_partial_groups,
+                    )
+                    all_chunks.extend(chunks)
+
+                all_buckets = chunk_to_bucket_ops(
+                    chunks=all_chunks,
+                    bucket_size=BUCKET_SIZE_BYTES,
                 )
-                print(
-                    f"    Generated {len(all_buckets)} buckets total ({len(all_buckets) // num_tensors_per_batch} per tensor)"
+
+                ir_gen_time = (time.perf_counter() - start_time) / profile_iter
+                if rank == 0:
+                    print(f"    IR generation time: {ir_gen_time:.6f}s")
+                    print(
+                        f"    Generated {len(all_chunks)} chunks total ({len(all_chunks) // num_tensors_per_batch} per tensor)"
+                    )
+                    print(
+                        f"    Generated {len(all_buckets)} buckets total ({len(all_buckets) // num_tensors_per_batch} per tensor)"
+                    )
+                    print(f"    m2m map: {m2m_map}")
+
+                # Create mesh info string for output directory organization
+                src = "_".join(map(str, source_mesh_shape))
+                tgt = "_".join(map(str, target_mesh_shape))
+                mesh_info = f"mesh_{mesh_idx + 1:02d}_{src}_{tgt}"
+
+                result = benchmark_single_shape(
+                    origin_tensors,
+                    source_dist_tensors,
+                    target_local_tensors,
+                    num_tensors_per_batch,
+                    shape,
+                    all_chunks,
+                    all_buckets,
+                    current_source_mesh,
+                    current_target_mesh,
+                    source_specs,
+                    target_specs,
+                    source_world_size,
+                    device,
+                    rank,
+                    local_rank,
+                    warmup_iter,
+                    profile_iter,
+                    gpus_per_node,
+                    profiling_config,
+                    mesh_info,
+                    has_partial=has_partial,
                 )
-                print(f"    m2m map: {m2m_map}")
 
-            # Create mesh info string for output directory organization
-            src = "_".join(map(str, source_mesh_shape))
-            tgt = "_".join(map(str, target_mesh_shape))
-            mesh_info = f"mesh_{mesh_idx + 1:02d}_{src}_{tgt}"
+                if result is not None:
+                    current_results.append(result)
 
-            result = benchmark_single_shape(
-                origin_tensors,
-                source_dist_tensors,
-                target_local_tensors,
-                shape,
-                all_chunks,
-                all_buckets,
-                current_source_mesh,
-                current_target_mesh,
-                source_specs,
-                target_specs,
-                source_world_size,
-                device,
-                rank,
-                local_rank,
-                warmup_iter,
-                profile_iter,
-                gpus_per_node,
-                profiling_config,
-                mesh_info,
-            )
+                # Clean up tensors after each shape benchmark
+                del origin_tensors, source_dist_tensors, target_local_tensors, all_chunks, all_buckets
+                if device == "cuda":
+                    torch.cuda.empty_cache()
 
-            if result is not None:
-                current_results.append(result)
+            # Generate plot for current mesh
+            if rank == 0 and current_results:
+                generate_result_plot(
+                    current_results,
+                    source_mesh_shape,
+                    target_mesh_shape,
+                    mesh_idx,
+                    num_tensors_per_batch,
+                    source_specs,
+                    target_specs,
+                    config_name=config_name,
+                    has_partial=has_partial,
+                )
+                all_results[f"{config_name}_mesh_{mesh_idx + 1}_{source_mesh_shape}_{target_mesh_shape}"] = (
+                    current_results
+                )
+                print(f"✅ [{config_name}] Mesh combination {mesh_idx + 1} test completed")
 
-            # Clean up tensors after each shape benchmark
-            del origin_tensors, source_dist_tensors, target_local_tensors, all_chunks, all_buckets
+            # Clear process group cache and GPU memory after each mesh combination
+            try:
+                from etha.comm.comm_methods import _PROCESS_GROUP_CACHE
+
+                _PROCESS_GROUP_CACHE.clear()
+            except ImportError:
+                pass
             if device == "cuda":
                 torch.cuda.empty_cache()
 
-        # Generate plot for current mesh
-        if rank == 0 and current_results:
-            generate_result_plot(
-                current_results,
-                source_mesh_shape,
-                target_mesh_shape,
-                mesh_idx,
-                num_tensors_per_batch,
-                source_specs,
-                target_specs,
-            )
-            all_results[f"mesh_{mesh_idx + 1}_{source_mesh_shape}_{target_mesh_shape}"] = current_results
-            print(f"✅ Mesh combination {mesh_idx + 1} test completed")
-
-        # Clear process group cache and GPU memory after each mesh combination
-        try:
-            from etha.comm.comm_methods import _PROCESS_GROUP_CACHE
-
-            _PROCESS_GROUP_CACHE.clear()
-        except ImportError:
-            pass
-        if device == "cuda":
-            torch.cuda.empty_cache()
-
-        print(f"Mesh combination {mesh_idx + 1}/{len(mesh_combinations)} processing completed")
+            print(f"Mesh combination {mesh_idx + 1}/{len(mesh_combinations)} processing completed")
 
     if rank == 0:
         print(f"\n{'=' * 80}")

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,9 +12,11 @@ inference cluster in a disaggregated RL setup, where the two sides were
 launched separately and run different parallelism configurations.
 
 :::{note}
-Supported placements are currently `Shard` and `Replicate`. `Partial` is
-rejected with `NotImplementedError` — redistribute it to `Replicate` or
-`Shard` on the source mesh before handing the DTensor to Etha.
+Supported source placements: `Shard`, `Replicate`, `Partial`. For `Partial`,
+Etha collapses it to `Replicate` on the source mesh via a chunk-level
+all-reduce before send. `Partial` on the target side is rejected:
+cross-process-group decomposition of a logical tensor into a Partial
+contribution is not uniquely defined.
 :::
 
 ```{toctree}

--- a/pixi.lock
+++ b/pixi.lock
@@ -20,6 +20,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py312h4c3975b_2.conda
@@ -46,6 +47,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.0-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312hd9148b4_3.conda
@@ -97,9 +99,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.5.0-py310hb823017_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
@@ -298,6 +302,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.5.9-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
@@ -305,11 +310,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.8-h813ae00_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.7.0-py312h0ccc70a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.3-py312h7a1785b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shtab-1.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
@@ -323,11 +330,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.5.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.2-py312h4c3975b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/transformers-5.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/triton-3.4.0-cuda129py312h811769c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.25.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
@@ -3668,6 +3679,26 @@ packages:
   - pkg:pypi/huggingface-hub?source=hash-mapping
   size: 417246
   timestamp: 1778094467832
+- conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.15.0-pyhd8ed1ab_0.conda
+  sha256: 71d200fe916b614061dd987cc94c2c373541210564cd74233e0cebf4114b8ac1
+  md5: b00e94a6d39ef6b787215a824aa3bedb
+  depends:
+  - filelock >=3.10.0
+  - fsspec >=2023.5.0
+  - hf-xet >=1.4.3,<2.0.0
+  - httpx >=0.23.0,<1
+  - packaging >=20.9
+  - python >=3.10
+  - pyyaml >=5.1
+  - requests
+  - tqdm >=4.42.1
+  - typer >=0.20.0
+  - typing-extensions >=3.7.4.3
+  - typing_extensions >=4.1.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 418023
+  timestamp: 1778854456651
 - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
   sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
   md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
@@ -11153,6 +11184,25 @@ packages:
   - pkg:pypi/transformers?source=compressed-mapping
   size: 3962753
   timestamp: 1778645573996
+- conda: https://conda.anaconda.org/conda-forge/noarch/transformers-5.9.0-pyhd8ed1ab_0.conda
+  sha256: 33bfd2055cc492cfdd149bce3e158c1d9a297c8aea57d65b65dcdea59ac2f8cd
+  md5: dbb07430fe646f873f3e5673472e1dd2
+  depends:
+  - filelock
+  - huggingface_hub >=1.3.0,<2.0
+  - numpy >=1.17
+  - packaging >=20.0
+  - python >=3.10
+  - pyyaml >=5.1
+  - regex !=2019.12.17
+  - requests
+  - safetensors >=0.4.1
+  - tokenizers >=0.22,<=0.23
+  - tqdm >=4.27
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4074128
+  timestamp: 1779300388504
 - conda: https://conda.anaconda.org/conda-forge/linux-64/triton-3.4.0-cuda129py312h811769c_1.conda
   sha256: 679cd856750442f8901914e1db96d504f038ef7d897e89db53a28c731d70d158
   md5: 34d933687688ffeeb4b828a9edd0b079

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,6 +29,7 @@ nccl-tests = ">=2.16.7,<3"
 pytest-timeout = ">=2.4.0,<3"
 mypy = ">=1.18.2,<2"
 tyro = ">=0.9.35,<0.10"
+transformers = "*"
 
 [feature.dev.tasks]
 test = "pytest tests"

--- a/src/etha/comm/get_chunks.py
+++ b/src/etha/comm/get_chunks.py
@@ -1,6 +1,7 @@
 """Get chunks from m2m map."""
 
 import torch
+import torch.distributed as dist
 
 from .ir import Chunk, TransferType
 from .utils import (
@@ -28,6 +29,7 @@ def map_to_chunk_ops(
     source_tensor: torch.Tensor | None = None,
     target_tensor: torch.Tensor | None = None,
     transfer_dtype: torch.dtype | None = None,
+    source_partial_groups: list[tuple[dist.ProcessGroup, str]] | None = None,
 ) -> list[Chunk]:
     if not m2m_map:
         return []
@@ -56,7 +58,10 @@ def map_to_chunk_ops(
     chunks: list[Chunk] = []
     for src_rank, src_map in m2m_map.items():
         for src_idx, dst_list in src_map.items():
-            if len(dst_list) > 1:
+            if not dst_list:
+                # Partial sub-group member with no ship task — joins reduce only.
+                transfer_type = TransferType.SHADOW
+            elif len(dst_list) > 1:
                 transfer_type = TransferType.BROADCAST
             else:
                 transfer_type = TransferType.P2P
@@ -79,6 +84,7 @@ def map_to_chunk_ops(
                         slice_tuples=src_slice_tuples,
                         tensor=source_tensor,
                         transfer_dtype=transfer_dtype,
+                        source_partial_groups=source_partial_groups,
                     )
                 )
             for dst_rank, dst_idx in dst_list:

--- a/src/etha/comm/get_m2m_map.py
+++ b/src/etha/comm/get_m2m_map.py
@@ -7,8 +7,10 @@ from collections import defaultdict
 
 import torch
 import torch.distributed as dist
-from torch.distributed._tensor import Shard, DeviceMesh, distribute_tensor
+from torch.distributed._tensor import Shard, Replicate, DeviceMesh, distribute_tensor
 from torch.distributed.tensor.placement_types import Partial, Placement
+
+from .utils import enumerate_partial_subgroup_ranks
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,60 @@ def get_shard_shape(device_mesh: tuple[int, ...], placements: tuple[Placement, .
     return shard_shape
 
 
+def _expand_partial_shadows(
+    m2m_map: dict[int, dict[tuple, list[tuple[int, tuple]]]],
+    source_mesh: DeviceMesh,
+    source_placements: tuple[Placement, ...],
+) -> dict[int, dict[tuple, list[tuple[int, tuple]]]]:
+    """Insert SHADOW entries so every Partial sub-group member participates in reduce.
+
+    Trace selects one primary per cell; the remaining Partial peers need SHADOW
+    entries (empty ``dst_list``) so they reach the chunk-level all-reduce.
+    Propagation is transitive: a rank's chunk at cell C drives *all* of its
+    sub-groups' reduces, so the whole connected component (sub-groups linked
+    via shared members) must be present at C.
+    """
+    sub_groups: list[list[int]] = []
+    mesh_tensor = source_mesh.mesh
+    for mesh_dim_idx, p in enumerate(source_placements):
+        if isinstance(p, Partial):
+            sub_groups.extend(enumerate_partial_subgroup_ranks(mesh_tensor, mesh_dim_idx))
+    expanded: dict[int, dict[tuple, list[tuple[int, tuple]]]] = {k: dict(v) for k, v in m2m_map.items()}
+    if not sub_groups:
+        return expanded
+
+    parent: dict[int, int] = {r: r for sg in sub_groups for r in sg}
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for sg in sub_groups:
+        anchor = sg[0]
+        for r in sg[1:]:
+            ra, rr = find(anchor), find(r)
+            if ra != rr:
+                parent[ra] = rr
+
+    component_members: dict[int, set[int]] = defaultdict(set)
+    for r in parent:
+        component_members[find(r)].add(r)
+
+    for src_rank, cells in list(m2m_map.items()):
+        if src_rank not in parent:
+            continue  # rank has no Partial sub-group; nothing to expand
+        comp = component_members[find(src_rank)]
+        for cell in cells:
+            for r in comp:
+                if r != src_rank:
+                    expanded.setdefault(r, {}).setdefault(cell, [])
+
+    # Sort cells so all component members iterate in lock-step.
+    return {r: {cell: expanded[r][cell] for cell in sorted(expanded[r].keys())} for r in expanded}
+
+
 def get_m2m_map(
     source_mesh: DeviceMesh,
     source_placements: tuple[Placement, ...],
@@ -43,39 +99,50 @@ def get_m2m_map(
     target_placements: tuple[Placement, ...],
     group: dist.ProcessGroup,
     device: str = "cpu",
-) -> tuple[dict[int, dict[tuple, list[tuple[int, tuple]]]], list[int], list[int]]:
+) -> tuple[
+    dict[int, dict[tuple, list[tuple[int, tuple]]]],
+    list[int],
+    list[int],
+    list[tuple[int, str]],
+]:
     """Get P2P communication map for tensor redistribution.
 
-    Only ``Shard`` and ``Replicate`` placements are supported. ``Partial`` is
-    rejected because the map is built by encoding ``rank`` + ``coord`` into a
-    middle tensor and shipping it via ``DTensor.full_tensor()``; for ``Partial``
-    that triggers an all-reduce which sums the encoded values across ranks and
-    corrupts the map.
+    Source Partial is supported by substituting Partial→Replicate for the trace,
+    then inserting SHADOW entries for the dropped peers via
+    ``_expand_partial_shadows``. Target Partial is rejected — the decomposition
+    of a logical tensor into Partial contributions is not uniquely defined
+    across an independent process-group boundary.
 
-    Raises:
-        NotImplementedError: If any of ``source_placements`` or
-            ``target_placements`` contains a ``Partial``.
+    Returns:
+        ``(m2m_map, source_num_slicers, target_num_slicers, source_partial_reductions)``.
+        The last is a list of ``(mesh_dim_idx, reduce_op_str)`` per Partial dim,
+        empty when source has no Partial.
     """
-    for placements, side in ((source_placements, "source"), (target_placements, "target")):
-        if any(isinstance(p, Partial) for p in placements):
-            raise NotImplementedError(
-                f"Partial placement is not supported (found in {side}_placements={placements}). "
-                "Etha currently supports only Shard and Replicate; redistribute Partial to "
-                "Replicate or Shard on the source mesh before handing the DTensor to Etha."
-            )
+    if any(isinstance(p, Partial) for p in target_placements):
+        raise NotImplementedError(
+            f"Partial placement in target_placements={target_placements} is not supported. "
+            "Cross-process-group decomposition of a logical tensor into a Partial "
+            "contribution is not uniquely defined; only source-side Partial is supported."
+        )
+
+    source_partial_reductions: list[tuple[int, str]] = [
+        (i, p.reduce_op) for i, p in enumerate(source_placements) if isinstance(p, Partial)
+    ]
+    effective_source_placements: tuple[Placement, ...] = tuple(
+        Replicate() if isinstance(p, Partial) else p for p in source_placements
+    )
+
     rank = dist.get_rank()
     target_mesh_ranks = target_mesh.mesh.flatten().tolist()
     source_mesh_ranks = source_mesh.mesh.flatten().tolist()
 
-    source_tensor_ndim = _get_tensor_ndim(source_placements)
+    source_tensor_ndim = _get_tensor_ndim(effective_source_placements)
     target_tensor_ndim = _get_tensor_ndim(target_placements)
     tensor_ndim = max(source_tensor_ndim, target_tensor_ndim)
 
-    # Calculate shard shapes
-    source_shard_shape = get_shard_shape(source_mesh.mesh.shape, source_placements, tensor_ndim)
+    source_shard_shape = get_shard_shape(source_mesh.mesh.shape, effective_source_placements, tensor_ndim)
     target_shard_shape = get_shard_shape(target_mesh.mesh.shape, target_placements, tensor_ndim)
 
-    # Calculate temporary tensor shape
     middle_tensor_shape = tuple(
         math.lcm(source_shard_shape[i], target_shard_shape[i]) for i in range(len(source_shard_shape))
     )
@@ -87,22 +154,19 @@ def get_m2m_map(
     for o, m, t in zip(source_shard_shape, middle_tensor_shape, target_shard_shape, strict=False):
         source_num_slicers.append(m // o)
         target_num_slicers.append(m // t)
+
     reqs = []
     if rank in source_mesh_ranks:
         middle_tensor = torch.zeros(middle_tensor_shape, device=device)
-        dtensor_source = distribute_tensor(middle_tensor, source_mesh, source_placements)
+        dtensor_source = distribute_tensor(middle_tensor, source_mesh, effective_source_placements)
         local_shard = dtensor_source.to_local()
         logger.debug(f"[P2P Map rank={rank}] Local Source Shard: {local_shard}")
-        # Create tensor with rank and coordinates encoded as single values
-        # Use dynamic base calculation to support arbitrary dimensions
         encoded_tensor = torch.zeros_like(local_shard)
 
-        # Calculate the maximum coordinate in any dimension to determine encoding base
         # Use middle_tensor_shape to ensure consistent base across all ranks
-        base = max(middle_tensor_shape) + 1  # Base should be larger than any coordinate
+        base = max(middle_tensor_shape) + 1
 
         for idx in itertools.product(*[range(dim) for dim in local_shard.shape]):
-            # Encode rank and coordinates into single value using dynamic base
             encoded_value = rank
             for coord in idx:
                 encoded_value = encoded_value * base + coord
@@ -111,18 +175,14 @@ def get_m2m_map(
         local_shard.copy_(encoded_tensor)
         full_tensor_restored = dtensor_source.full_tensor()
 
-        # Find index in source mesh
         source_idx = source_mesh_ranks.index(rank)
-        # Map to target ranks using original pattern: start from source_idx, step by source mesh size
         for target_idx in range(source_idx, len(target_mesh_ranks), len(source_mesh_ranks)):
             target_rank = target_mesh_ranks[target_idx]
             logger.debug(f"[P2P Map rank={rank}] Sending to target rank: {target_rank}")
             reqs.append(dist.isend(full_tensor_restored, dst=target_rank))
 
     elif rank in target_mesh_ranks:
-        # Target ranks receive from source ranks
         full_tensor_restored = torch.empty(middle_tensor_shape, device=device)
-        # Find index in target mesh and map to corresponding source rank
         target_idx = target_mesh_ranks.index(rank)
         source_rank = source_mesh_ranks[target_idx % len(source_mesh_ranks)]
 
@@ -139,16 +199,11 @@ def get_m2m_map(
         dtensor_target = distribute_tensor(full_tensor_restored, target_mesh, target_placements, src_data_rank=None)
         local_target_shard = dtensor_target.to_local()
         logger.debug(f"[M2M Map rank={rank}] Local Target Shard: {local_target_shard}")
-        # Calculate the same base used for encoding
-        # Use middle_tensor_shape to ensure consistent base across all ranks
         base = max(middle_tensor_shape) + 1
 
-        # Iterate through all indices in the local shard
         for target_idx_tuple in itertools.product(*[range(dim) for dim in local_target_shard.shape]):
             encoded_value = int(local_target_shard[target_idx_tuple].item())
 
-            # Decode the rank and source indices from the encoded value
-            # Extract coordinates in reverse order
             source_indices = []
             temp = encoded_value
             for _ in range(len(target_idx_tuple)):
@@ -156,10 +211,8 @@ def get_m2m_map(
                 source_indices.append(coord)
                 temp = temp // base
 
-            # The remaining value is the source rank
             source_rank = temp
 
-            # Reverse the indices list since we extracted them in reverse order
             source_indices.reverse()
             source_idx = tuple(source_indices)
 
@@ -180,9 +233,10 @@ def get_m2m_map(
                 for source_idx, target_info_list in source_idx_map.items():
                     merged_m2m_map[source_rank][source_idx].extend(target_info_list)
 
-    # Convert nested defaultdict to regular dict
     final_m2m_map = {}
     for source_rank, source_idx_map in merged_m2m_map.items():
         final_m2m_map[source_rank] = dict(source_idx_map)
 
-    return final_m2m_map, source_num_slicers, target_num_slicers
+    final_m2m_map = _expand_partial_shadows(final_m2m_map, source_mesh, source_placements)
+
+    return final_m2m_map, source_num_slicers, target_num_slicers, source_partial_reductions

--- a/src/etha/comm/ir.py
+++ b/src/etha/comm/ir.py
@@ -1,13 +1,22 @@
 """Intermediate Representation for tensor transfer operations."""
 
 import logging
-from dataclasses import dataclass
+from dataclasses import field, dataclass
 
 import torch
+import torch.distributed as dist
 
 from .transfer import Transferable, TransferType
 
 logger = logging.getLogger(__name__)
+
+_REDUCE_OP_MAP = {
+    "sum": dist.ReduceOp.SUM,
+    "avg": dist.ReduceOp.AVG,
+    "max": dist.ReduceOp.MAX,
+    "min": dist.ReduceOp.MIN,
+    "product": dist.ReduceOp.PRODUCT,
+}
 
 
 @dataclass(slots=True, kw_only=True)
@@ -21,6 +30,10 @@ class Chunk(Transferable):
     src_idx: tuple  # Multi-dimensional index in source tensor
     dst_idx: tuple | None = None  # Multi-dimensional index in target tensor (recv/self-copy only)
     src_slice_tuples: tuple[slice, ...] | None = None  # Source slice (self-copy only)
+    # NCCL sub-groups + reduce_op for collapsing source Partial to Replicate
+    # before send. Routing emits a chunk per (member, cell) so every member
+    # reaches the collective; SHADOW chunks participate without shipping.
+    source_partial_groups: list[tuple[dist.ProcessGroup, str]] | None = field(default=None)
 
     def __post_init__(self) -> None:
         if self.transfer_dtype is None:
@@ -36,10 +49,13 @@ class Chunk(Transferable):
         )
 
     def prepare(self, contiguous: bool = True) -> None:
-        """Prepare buffer from tensor slice.
+        """Prepare source/target buffer.
 
-        Args:
-            contiguous: Whether to make buffer contiguous (default True)
+        Source side performs (in order): slice → in-place all-reduce on
+        Partial sub-groups (in source dtype) → cast to ``transfer_dtype``.
+        Reducing before the cast matches DTensor ``Partial → Replicate``
+        semantics; running the all-reduce in the (possibly lower-precision)
+        wire dtype would change numerical results.
         """
         if self.transfer_type == TransferType.SELF_COPY:
             buffer = self.tensor[self.src_slice_tuples]
@@ -47,9 +63,20 @@ class Chunk(Transferable):
             buffer = self.tensor[self.slice_tuples]
             if contiguous:
                 buffer = buffer.contiguous()
-        # Source: convert to transfer_dtype if specified and different
-        if self.is_source and self.transfer_dtype and self.transfer_dtype != buffer.dtype:
-            buffer = buffer.to(self.transfer_dtype)
+
+        if self.is_source and self.transfer_type != TransferType.SELF_COPY:
+            if self.source_partial_groups:
+                # all_reduce is in-place; ensure we own the storage so the
+                # source tensor isn't mutated. Storage-level alias check —
+                # ``tensor.data_ptr()`` accounts for ``storage_offset`` and
+                # would miss non-zero-offset slices that still alias.
+                if buffer.untyped_storage().data_ptr() == self.tensor.untyped_storage().data_ptr():
+                    buffer = buffer.contiguous().clone()
+                for group, op_str in self.source_partial_groups:
+                    dist.all_reduce(buffer, op=_REDUCE_OP_MAP[op_str], group=group)
+            if self.transfer_dtype and self.transfer_dtype != buffer.dtype:
+                buffer = buffer.to(self.transfer_dtype)
+
         self.buffer = buffer
 
     def finalize(self) -> None:
@@ -67,8 +94,21 @@ class Chunk(Transferable):
 
     @property
     def bucket_key(self) -> tuple:
-        """Return bucket grouping key (src_rank, dst_ranks)."""
-        return (self.src_rank, self.dst_ranks)
+        """Return bucket grouping key.
+
+        ``cell_key`` is added for SHADOW Partial chunks only — they all share
+        ``dst_ranks=()`` and would otherwise bundle across cells, making the
+        bucket's all_reduce sequence per-rank-specific and out of sync with
+        peer ranks whose matching cells live in separate buckets. PRIMARY
+        chunks already differ by ``dst_ranks`` across cells.
+        """
+        partial_sig: tuple = ()
+        cell_key: tuple = ()
+        if self.source_partial_groups:
+            partial_sig = tuple((id(g), op) for g, op in self.source_partial_groups)
+            if not self.dst_ranks:
+                cell_key = self.src_idx
+        return (self.src_rank, self.dst_ranks, partial_sig, cell_key)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -96,8 +136,12 @@ class Bucket(Transferable):
         return f"Bucket({kind}, key={self.key} entries_len={len(self.entries)} src_rank={self.src_rank}→dst_ranks={self.dst_ranks})"
 
     def prepare(self) -> None:
-        """Prepare buffer for communication."""
-        # Single entry fast path
+        """Prepare buffer for communication.
+
+        Source-side Partial reduce and dtype cast both live inside
+        ``Chunk.prepare``; this method only assembles entries into the
+        bucket buffer.
+        """
         if len(self.entries) == 1:
             chunk = self.entries[0].chunk
             chunk.prepare()
@@ -106,7 +150,6 @@ class Bucket(Transferable):
                 chunk.buffer = None
             return
 
-        # Multi-entry: allocate bucket buffer
         self.buffer = torch.empty(self.total_bytes, dtype=torch.uint8, device=self.device)
         needs_copy = self.is_source or self.transfer_type == TransferType.SELF_COPY
 

--- a/src/etha/comm/transfer.py
+++ b/src/etha/comm/transfer.py
@@ -15,6 +15,10 @@ class TransferType(Enum):
     SELF_COPY = "self_copy"  # Local copy within same rank
     P2P = "p2p"
     BROADCAST = "broadcast"
+    # Reduce-only chunks: a source rank participates in the source-Partial
+    # all-reduce (collective; every sub-group member must call) but isn't the
+    # ship-primary for this logical cell. After reduce, the buffer is discarded.
+    SHADOW = "shadow"
 
 
 def _execute_p2p(
@@ -56,10 +60,12 @@ class Transferable:
         """Execute transfer operation.
 
         Returns:
-            Work handle for async operations, None for SELF_COPY.
+            Work handle for async operations, None for SELF_COPY / SHADOW.
         """
         match self.transfer_type:
             case TransferType.SELF_COPY:
+                return None
+            case TransferType.SHADOW:
                 return None
             case TransferType.P2P:
                 return _execute_p2p(self.buffer, self.is_source, self.src_rank, self.dst_ranks[0])

--- a/src/etha/comm/utils.py
+++ b/src/etha/comm/utils.py
@@ -10,7 +10,36 @@ import torch
 # Re-export for backward compatibility
 from etha.pg_utils import get_or_create_process_group
 
-__all__ = ["get_or_create_process_group", "get_slicer_tuples", "get_slice_from_multi_index"]
+__all__ = [
+    "get_or_create_process_group",
+    "get_slicer_tuples",
+    "get_slice_from_multi_index",
+    "enumerate_partial_subgroup_ranks",
+]
+
+
+def enumerate_partial_subgroup_ranks(
+    mesh_tensor: torch.Tensor,
+    mesh_dim_idx: int,
+) -> list[list[int]]:
+    """Sub-group rank lists, one per slice through ``mesh_dim_idx``.
+
+    Each sub-group is the set of ranks that share all coordinates except along
+    ``mesh_dim_idx`` — i.e., the ranks that contribute to one all-reduce when
+    collapsing a ``Partial`` dim to ``Replicate``.
+    """
+    ndim = mesh_tensor.dim()
+    if not 0 <= mesh_dim_idx < ndim:
+        raise ValueError(f"mesh_dim_idx must be in [0, {ndim}), got {mesh_dim_idx}")
+    other_dims = [d for d in range(ndim) if d != mesh_dim_idx]
+    other_sizes = [mesh_tensor.shape[d] for d in other_dims]
+    sub_groups: list[list[int]] = []
+    for other_coords in itertools.product(*[range(s) for s in other_sizes]):
+        slicer: list = [slice(None)] * ndim
+        for di, ci in zip(other_dims, other_coords, strict=False):
+            slicer[di] = ci
+        sub_groups.append(mesh_tensor[tuple(slicer)].flatten().tolist())
+    return sub_groups
 
 
 def get_slicer_tuples(tensor_shape: torch.Size, source_num_slicers: list[int]) -> list[tuple[slice, ...]]:

--- a/src/etha/tensor_bus/agent.py
+++ b/src/etha/tensor_bus/agent.py
@@ -19,7 +19,7 @@ import posix_ipc
 import torch.distributed as dist
 from upath import UPath
 from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.tensor.placement_types import Placement
+from torch.distributed.tensor.placement_types import Partial, Placement
 
 from etha.comm import (
     chunk_comm,
@@ -31,6 +31,7 @@ from etha.comm import (
 from etha.comm.ir import Chunk
 from etha.kvstore import KVStore, create_store
 from etha.pg_utils import get_or_create_process_group
+from etha.comm.utils import enumerate_partial_subgroup_ranks
 
 from .utils import setup_cuda_rebuild_patch
 from .commands import InitPair, Transfer, QueryStatus, CleanupBatch, RegisterTensors
@@ -41,6 +42,33 @@ from .command_queue import CommandQueue
 logger = logging.getLogger(__name__)
 
 TIME_INTERVAL = 0.001  # 1ms
+
+
+def _create_partial_groups(
+    mesh_tensor: torch.Tensor,
+    partial_reductions: list[tuple[int, str]],
+    this_rank: int,
+    full_source_ranks: list[int],
+    full_source_group: dist.ProcessGroup,
+) -> list[tuple[dist.ProcessGroup, str]]:
+    """Create NCCL sub-groups for each Partial dim; return groups this rank belongs to.
+
+    ``dist.new_group`` is collective on WORLD, so every WORLD rank must call it in
+    the same order — non-members included. Reuses ``full_source_group`` when a
+    sub-group spans the entire source side (the common 1D-mesh-single-Partial case),
+    avoiding a redundant new_group bootstrap.
+    """
+    my_groups: list[tuple[dist.ProcessGroup, str]] = []
+    full_set = set(full_source_ranks)
+    for mesh_dim_idx, reduce_op in partial_reductions:
+        for sub_ranks in enumerate_partial_subgroup_ranks(mesh_tensor, mesh_dim_idx):
+            if set(sub_ranks) == full_set:
+                group = full_source_group
+            else:
+                group = get_or_create_process_group(sub_ranks)
+            if this_rank in sub_ranks:
+                my_groups.append((group, reduce_op))
+    return my_groups
 
 
 class TensorBusAgent:
@@ -267,6 +295,11 @@ class TensorBusAgent:
         # We use alphabetical order of role names as the tie-breaker
         local_is_first = local_name < remote_name
 
+        # Canonical (first, second) swap helper. Same on every rank, used to align
+        # paired-by-side data (mesh, placements, ranks, group) before collectives.
+        def _order(loc, rem):
+            return (loc, rem) if local_is_first else (rem, loc)
+
         if local_mesh_info and remote_mesh_info:
             # Get local mesh info (this process's mesh)
             local_mesh_shape, local_placements = local_mesh_info[0]
@@ -280,62 +313,71 @@ class TensorBusAgent:
             logger.info(f"Agent {self.rank}: Local mesh: {local_mesh_tensor} with placements: {local_placements}")
             logger.info(f"Agent {self.rank}: Remote mesh: {remote_mesh_tensor} with placements: {remote_placements}")
 
-            if local_is_first:
-                first_mesh = DeviceMesh("cpu", local_mesh_tensor)
-                second_mesh = DeviceMesh("cpu", remote_mesh_tensor)
-                first_placements = local_placements
-                second_placements = remote_placements
-            else:
-                first_mesh = DeviceMesh("cpu", remote_mesh_tensor)
-                second_mesh = DeviceMesh("cpu", local_mesh_tensor)
-                first_placements = remote_placements
-                second_placements = local_placements
+            first_mesh_tensor, second_mesh_tensor = _order(local_mesh_tensor, remote_mesh_tensor)
+            first_mesh = DeviceMesh("cpu", first_mesh_tensor)
+            second_mesh = DeviceMesh("cpu", second_mesh_tensor)
+            first_placements, second_placements = _order(local_placements, remote_placements)
             logger.info(f"Agent {self.rank}: Generating M2M maps for pair '{pair_name}'")
 
             # Generate M2M Maps (topology layer, shape-independent)
             # IMPORTANT: All ranks must call in the same order to avoid deadlock
-            # First call: first_mesh -> second_mesh
-            map_1, src_slicers_1, tgt_slicers_1 = get_m2m_map(
-                source_mesh=first_mesh,
-                source_placements=first_placements,
-                target_mesh=second_mesh,
-                target_placements=second_placements,
-                group=pair_group,
-                device="cpu",
-            )
-            # Second call: second_mesh -> first_mesh
-            map_2, src_slicers_2, tgt_slicers_2 = get_m2m_map(
-                source_mesh=second_mesh,
-                source_placements=second_placements,
-                target_mesh=first_mesh,
-                target_placements=first_placements,
-                group=pair_group,
-                device="cpu",
-            )
+            # in get_m2m_map's collective ops. Partial is supported only on
+            # *source* — skip the direction whose target side has Partial
+            # (cross-PG decomposition into Partial is undefined). Placement
+            # info is consistent across ranks via _collect_mesh_placement_info,
+            # so this branch is taken identically everywhere.
+            first_has_partial = any(isinstance(p, Partial) for p in first_placements)
+            second_has_partial = any(isinstance(p, Partial) for p in second_placements)
 
-            # Assign to send/recv based on which mesh is local
-            if local_is_first:
-                m2m_map_send = M2MMap(
-                    m2m_map=map_1,
-                    source_num_slicers=src_slicers_1,
-                    target_num_slicers=tgt_slicers_1,
-                )
-                m2m_map_recv = M2MMap(
-                    m2m_map=map_2,
-                    source_num_slicers=src_slicers_2,
-                    target_num_slicers=tgt_slicers_2,
+            map_1 = src_slicers_1 = tgt_slicers_1 = partial_red_1 = None
+            map_2 = src_slicers_2 = tgt_slicers_2 = partial_red_2 = None
+
+            # First call: first_mesh -> second_mesh (skip if second is Partial target)
+            if not second_has_partial:
+                map_1, src_slicers_1, tgt_slicers_1, partial_red_1 = get_m2m_map(
+                    source_mesh=first_mesh,
+                    source_placements=first_placements,
+                    target_mesh=second_mesh,
+                    target_placements=second_placements,
+                    group=pair_group,
+                    device="cpu",
                 )
             else:
-                m2m_map_send = M2MMap(
-                    m2m_map=map_2,
-                    source_num_slicers=src_slicers_2,
-                    target_num_slicers=tgt_slicers_2,
+                logger.info(
+                    f"Agent {self.rank}: Skipping first->second M2M map for pair '{pair_name}' "
+                    f"(second side has Partial placement; cross-PG Partial target is not supported)"
                 )
-                m2m_map_recv = M2MMap(
-                    m2m_map=map_1,
-                    source_num_slicers=src_slicers_1,
-                    target_num_slicers=tgt_slicers_1,
+
+            # Second call: second_mesh -> first_mesh (skip if first is Partial target)
+            if not first_has_partial:
+                map_2, src_slicers_2, tgt_slicers_2, partial_red_2 = get_m2m_map(
+                    source_mesh=second_mesh,
+                    source_placements=second_placements,
+                    target_mesh=first_mesh,
+                    target_placements=first_placements,
+                    group=pair_group,
+                    device="cpu",
                 )
+            else:
+                logger.info(
+                    f"Agent {self.rank}: Skipping second->first M2M map for pair '{pair_name}' "
+                    f"(first side has Partial placement; cross-PG Partial target is not supported)"
+                )
+
+            def _wrap(m, srcs, tgts, partial_red):
+                if m is None:
+                    return None
+                return M2MMap(
+                    m2m_map=m,
+                    source_num_slicers=srcs,
+                    target_num_slicers=tgts,
+                    source_partial_reductions=partial_red,
+                )
+
+            m2m_first_to_second = _wrap(map_1, src_slicers_1, tgt_slicers_1, partial_red_1)
+            m2m_second_to_first = _wrap(map_2, src_slicers_2, tgt_slicers_2, partial_red_2)
+            # Send is "local -> remote", so it's map_1 when local is first.
+            m2m_map_send, m2m_map_recv = _order(m2m_first_to_second, m2m_second_to_first)
             logger.info(
                 f"Agent {self.rank}: Generated P2P maps for pair '{pair_name}'. m2m_map_send: {m2m_map_send} m2m_map_recv: {m2m_map_recv}"
             )
@@ -349,13 +391,32 @@ class TensorBusAgent:
         else:
             logger.info(f"Agent {self.rank}: Skipping P2P map generation - missing or inconsistent mesh/placement info")
 
-        # Step 9: Create PairState
-        if local_is_first:
-            local_group = get_or_create_process_group(local_ranks)
-            get_or_create_process_group(remote_ranks)
-        else:
-            get_or_create_process_group(remote_ranks)
-            local_group = get_or_create_process_group(local_ranks)
+        # Step 9: Create local_group and remote_group (NCCL groups for send/recv side).
+        # Create in canonical (first, second) order so non-member ranks call new_group
+        # in the same sequence — new_group is WORLD-collective.
+        first_ranks, second_ranks = _order(local_ranks, remote_ranks)
+        first_group = get_or_create_process_group(first_ranks)
+        second_group = get_or_create_process_group(second_ranks)
+        local_group, remote_group = _order(first_group, second_group)
+
+        # Both directions' Partial sub-groups are created in deterministic order
+        # for the same reason; only the local-side groups are kept.
+        source_partial_groups: list[tuple[dist.ProcessGroup, str]] | None = None
+        if local_mesh_info and remote_mesh_info:
+            mesh_1_partial_groups = _create_partial_groups(
+                first_mesh_tensor, partial_red_1, self.rank, first_ranks, first_group
+            )
+            mesh_2_partial_groups = _create_partial_groups(
+                second_mesh_tensor, partial_red_2, self.rank, second_ranks, second_group
+            )
+
+            local_partial_groups, _ = _order(mesh_1_partial_groups, mesh_2_partial_groups)
+            source_partial_groups = local_partial_groups or None
+            if source_partial_groups:
+                logger.info(
+                    f"Agent {self.rank}: Created {len(source_partial_groups)} source Partial sub-group(s) "
+                    f"for pair '{pair_name}'"
+                )
 
         state = PairState(
             pair_name=pair_name,
@@ -369,6 +430,7 @@ class TensorBusAgent:
             local_is_first=local_is_first,
             m2m_send=m2m_map_send,
             m2m_recv=m2m_map_recv,
+            source_partial_groups=source_partial_groups,
         )
         self.pairs[pair_name] = state
 
@@ -429,6 +491,15 @@ class TensorBusAgent:
                     f"Agent {self.rank}: Batch {batch_id}: Executing chunk-based transfer with {len(chunks)} chunks"
                 )
                 chunk_comm(chunks=chunks)
+            else:
+                # The other direction produced chunks, but this one is empty —
+                # init_pair skipped it because the target side has a Partial
+                # placement (cross-PG Partial target is unsupported).
+                raise RuntimeError(
+                    f"Batch {batch_id}: no {transfer_type} chunks. The pair's "
+                    f"{transfer_type} direction has a Partial target, which is "
+                    f"not supported. Partial is only valid as a source placement."
+                )
         else:
             # Fall back to simple send/recv without P2P optimization
             logger.info(f"Agent {self.rank}: Batch {batch_id}: Using simple send/recv transfer (no P2P map available)")
@@ -574,7 +645,7 @@ class TensorBusAgent:
                 batch_state.pair_target_dtypes[pair_name].append(target_dtype)
                 logger.debug(f"Agent {self.rank}: Batch {batch_id}: tensor {i} target dtype {target_dtype}")
 
-                if pair_state.m2m_send and pair_state.m2m_recv:
+                if pair_state.m2m_send or pair_state.m2m_recv:
                     logger.debug(
                         f"Agent {self.rank}: Batch {batch_id}: Generating chunks for tensor {i} with shape {tensor.shape}"
                     )
@@ -590,29 +661,30 @@ class TensorBusAgent:
                             f"(my={tensor.dtype}, remote={target_dtype})"
                         )
 
-                    # Generate send chunks for this tensor
-                    send_chunks = map_to_chunk_ops(
-                        m2m_map=pair_state.m2m_send.m2m_map,
-                        rank=self.rank,
-                        source_num_slicers=pair_state.m2m_send.source_num_slicers,
-                        target_num_slicers=pair_state.m2m_send.target_num_slicers,
-                        source_tensor=tensor,
-                        target_tensor=None,
-                        transfer_dtype=transfer_dtype,
-                    )
-                    pair_send_chunks.extend(send_chunks)
+                    if pair_state.m2m_send is not None:
+                        send_chunks = map_to_chunk_ops(
+                            m2m_map=pair_state.m2m_send.m2m_map,
+                            rank=self.rank,
+                            source_num_slicers=pair_state.m2m_send.source_num_slicers,
+                            target_num_slicers=pair_state.m2m_send.target_num_slicers,
+                            source_tensor=tensor,
+                            target_tensor=None,
+                            transfer_dtype=transfer_dtype,
+                            source_partial_groups=pair_state.source_partial_groups,
+                        )
+                        pair_send_chunks.extend(send_chunks)
 
-                    # Generate recv chunks for this tensor
-                    recv_chunks = map_to_chunk_ops(
-                        m2m_map=pair_state.m2m_recv.m2m_map,
-                        rank=self.rank,
-                        source_num_slicers=pair_state.m2m_recv.source_num_slicers,
-                        target_num_slicers=pair_state.m2m_recv.target_num_slicers,
-                        source_tensor=None,
-                        target_tensor=tensor,
-                        transfer_dtype=transfer_dtype,
-                    )
-                    pair_recv_chunks.extend(recv_chunks)
+                    if pair_state.m2m_recv is not None:
+                        recv_chunks = map_to_chunk_ops(
+                            m2m_map=pair_state.m2m_recv.m2m_map,
+                            rank=self.rank,
+                            source_num_slicers=pair_state.m2m_recv.source_num_slicers,
+                            target_num_slicers=pair_state.m2m_recv.target_num_slicers,
+                            source_tensor=None,
+                            target_tensor=tensor,
+                            transfer_dtype=transfer_dtype,
+                        )
+                        pair_recv_chunks.extend(recv_chunks)
 
             # Accumulate to flattened lists
             all_send_chunks.extend(pair_send_chunks)

--- a/src/etha/tensor_bus/client.py
+++ b/src/etha/tensor_bus/client.py
@@ -200,10 +200,10 @@ class TensorBusClient:
             remote_name: Name of remote peer
             expected_world_size: Number of ranks for local peer
             device_mesh: Local device mesh configuration
-            placements: Local tensor placement strategy. Only ``Shard`` and
-                ``Replicate`` are supported; ``Partial`` is rejected at M2M
-                map construction time (redistribute it to ``Replicate`` or
-                ``Shard`` on the source mesh first).
+            placements: Local tensor placement strategy. ``Shard``, ``Replicate``
+                and ``Partial`` are supported on the source side; ``Partial`` is
+                collapsed to ``Replicate`` via an all-reduce on the source mesh
+                sub-group before send. ``Partial`` on the target side is rejected.
 
         Blocks until:
             - Agent registers to TCPStore

--- a/src/etha/tensor_bus/pair_state.py
+++ b/src/etha/tensor_bus/pair_state.py
@@ -13,6 +13,10 @@ class M2MMap(msgspec.Struct):
     m2m_map: dict[int, dict[tuple, list[tuple[int, tuple]]]] | None = None
     source_num_slicers: list[int] | None = None  # How source tensor is partitioned
     target_num_slicers: list[int] | None = None  # How target tensor is partitioned
+    # Partial placements found on the source mesh, as (mesh_dim_idx, reduce_op).
+    # The caller must all-reduce each Partial dim on the corresponding source
+    # sub-group before send; empty when source has no Partial.
+    source_partial_reductions: list[tuple[int, str]] = []
 
 
 class PairState(msgspec.Struct):
@@ -36,3 +40,9 @@ class PairState(msgspec.Struct):
     # Topology layer: M2M maps (shape-independent, reusable across batches)
     m2m_send: M2MMap | None = None  # Map for sending (local -> remote)
     m2m_recv: M2MMap | None = None  # Map for receiving (remote -> local)
+
+    # NCCL sub-groups for the partial dims on the *local* side of m2m_send
+    # (None if no Partial placements). Each entry: (sub_group, reduce_op_str);
+    # populated only on the sender side of the pair. The send pipeline runs
+    # an in-place all-reduce on these groups before the actual P2P send.
+    source_partial_groups: list[tuple[dist.ProcessGroup, str]] | None = None

--- a/tests/distributed_model_transfer/common.py
+++ b/tests/distributed_model_transfer/common.py
@@ -14,7 +14,7 @@ MESH_CONFIGS = {
 }
 
 STORE_HOST = os.environ.get("MASTER_ADDR", "localhost")
-STORE_PORT = 40001
+STORE_PORT = int(os.environ.get("ETHA_STORE_PORT", 40001))
 STORE_BACKEND = "tcp"
 LMDB_ROOT = os.environ.get("LMDB_ROOT", "/tmp/dbs")
 

--- a/tests/test_communication_cpu.py
+++ b/tests/test_communication_cpu.py
@@ -61,7 +61,7 @@ def run_test_communication(
 
     # Generate chunk IR using new API
     # Step 1: Get M2M map
-    m2m_map, source_num_slicers, target_num_slicers = get_m2m_map(
+    m2m_map, source_num_slicers, target_num_slicers, _ = get_m2m_map(
         source_mesh=source_mesh,
         source_placements=source_specs,
         target_mesh=target_mesh,

--- a/tests/test_communication_replicate_shard.py
+++ b/tests/test_communication_replicate_shard.py
@@ -18,12 +18,28 @@ import logging
 import torch
 import pytest
 import torch.distributed as dist
+from torch.distributed.tensor import DTensor
 from torch.distributed._tensor import Shard, Replicate, DeviceMesh, distribute_tensor
+from torch.distributed.tensor.placement_types import Partial
 
-from etha.comm import chunk_comm, get_m2m_map, map_to_chunk_ops
+from etha.comm import chunk_comm, bucket_comm, get_m2m_map, map_to_chunk_ops, chunk_to_bucket_ops
+from etha.tensor_bus.agent import _create_partial_groups
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def _local_shape(
+    tensor_shape: tuple[int, ...],
+    mesh_shape: tuple[int, ...],
+    placements: tuple,
+) -> tuple[int, ...]:
+    """Per-rank local shape after Shard partitioning."""
+    local = list(tensor_shape)
+    for mesh_dim, p in enumerate(placements):
+        if isinstance(p, Shard):
+            local[p.dim] //= mesh_shape[mesh_dim]
+    return tuple(local)
 
 
 def _run(
@@ -36,6 +52,7 @@ def _run(
     tensor_shape: tuple[int, ...],
     device: str,
     slice_view: bool = False,
+    comm_method: str = "chunk",
 ) -> None:
     dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
     source_ws = math.prod(source_mesh_shape)
@@ -53,7 +70,33 @@ def _run(
     tgt_global = torch.randn(tensor_shape, device=device)
 
     is_source = rank < source_ws
-    if slice_view:
+    has_partial_source = any(isinstance(p, Partial) for p in source_placements)
+    if has_partial_source:
+        # Partial cannot be the entry point to distribute_tensor; build per-rank
+        # random local contributions and wrap with DTensor.from_local. The
+        # logical (post-reduce) tensor is the cross-PG ground truth.
+        torch.manual_seed(1000 + rank)
+        if is_source:
+            src_local_shape = _local_shape(tensor_shape, source_mesh_shape, source_placements)
+            src_local = torch.randn(src_local_shape, device=device)
+            src_dt = DTensor.from_local(src_local, source_mesh, list(source_placements))
+            tgt_dt, tgt_local = None, None
+        else:
+            tgt_dt = distribute_tensor(tgt_global, target_mesh, list(target_placements))
+            tgt_local = tgt_dt.to_local()
+            src_dt, src_local = None, None
+        # Compute logical (post-reduce) tensor on source side, send to every target
+        # rank so each one has a ground truth to compare against after the reshard.
+        if is_source:
+            full_logical = src_dt.redistribute(source_mesh, [Replicate()] * len(source_placements)).to_local()
+        else:
+            full_logical = torch.empty(tensor_shape, device=device)
+        if is_source and rank == 0:
+            for tr in range(source_ws, world_size):
+                dist.send(full_logical, dst=tr)
+        if not is_source:
+            dist.recv(full_logical, src=0)
+    elif slice_view:
         wide_shape = list(tensor_shape)
         wide_shape[1] *= 2
         torch.manual_seed(42)
@@ -78,13 +121,24 @@ def _run(
             tgt_local = tgt_dt.to_local()
             src_dt, src_local = None, None
 
-    m2m_map, src_slicers, tgt_slicers = get_m2m_map(
+    m2m_map, src_slicers, tgt_slicers, partial_red = get_m2m_map(
         source_mesh=source_mesh,
         source_placements=list(source_placements),
         target_mesh=target_mesh,
         target_placements=list(target_placements),
         group=dist.group.WORLD,
         device=device,
+    )
+
+    # Source-side Partial sub-groups (collective on WORLD; non-members still call).
+    source_ranks_list = list(range(source_ws))
+    source_group = dist.new_group(ranks=source_ranks_list)
+    source_partial_groups = _create_partial_groups(
+        mesh_tensor=source_mesh.mesh,
+        partial_reductions=partial_red,
+        this_rank=rank,
+        full_source_ranks=source_ranks_list,
+        full_source_group=source_group,
     )
 
     chunks = map_to_chunk_ops(
@@ -94,11 +148,35 @@ def _run(
         target_num_slicers=tgt_slicers,
         source_tensor=src_local,
         target_tensor=tgt_local,
+        source_partial_groups=source_partial_groups or None,
     )
-    chunk_comm(chunks=chunks)
+    # Snapshot the source tensor so we can verify the Partial reduce path did
+    # not mutate the worker's data via an aliasing in-place all_reduce.
+    src_local_snapshot = (
+        src_local.detach().clone() if (is_source and has_partial_source and src_local is not None) else None
+    )
+    match comm_method:
+        case "chunk":
+            chunk_comm(chunks=chunks)
+        case "bucket":
+            buckets = chunk_to_bucket_ops(chunks=chunks, bucket_size=256 * 1024 * 1024)
+            bucket_comm(buckets=buckets)
+        case _:
+            raise ValueError(f"unknown comm_method: {comm_method}")
+
+    if is_source and src_local_snapshot is not None:
+        assert torch.equal(src_local, src_local_snapshot), (
+            f"source tensor was mutated by Partial reduce on rank {rank}: "
+            f"max diff {(src_local - src_local_snapshot).abs().max().item()}"
+        )
 
     if not is_source:
-        if slice_view:
+        if has_partial_source:
+            full = tgt_dt.full_tensor()
+            assert torch.allclose(full, full_logical, rtol=1e-4, atol=1e-4), (
+                f"partial reshard mismatch on rank {rank}: max diff {(full - full_logical).abs().max().item()}"
+            )
+        elif slice_view:
             tgt_full = tgt_dt.full_tensor()
             half = tensor_shape[1]
             got = tgt_full[:, :half, :]
@@ -120,6 +198,135 @@ def _run(
             )
 
     dist.destroy_process_group()
+
+
+def _run_partial_mixed_dtype(
+    rank: int,
+    world_size: int,
+    source_ws: int,
+    target_ws: int,
+    tensor_shape: tuple[int, ...],
+    device: str,
+    comm_method: str,
+) -> None:
+    """fp32 Partial source → bf16 Replicate target.
+
+    Regression for the P1: source-side all-reduce must happen in the source
+    (fp32) dtype before the cast to ``transfer_dtype`` (bf16), matching
+    DTensor's ``Partial → Replicate`` semantics. Inputs are scaled large so
+    the alternative (cast-first then bf16 all-reduce) diverges enough from
+    the fp32-reduce-then-cast reference to exceed the allclose tolerance.
+    """
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+    source_mesh_shape = (source_ws,)
+    target_mesh_shape = (target_ws,)
+    source_placements = (Partial(),)
+    target_placements = (Replicate(),)
+    transfer_dtype = torch.bfloat16
+
+    source_mesh = DeviceMesh(device, torch.arange(source_ws).view(source_mesh_shape))
+    target_mesh = DeviceMesh(
+        device,
+        torch.arange(source_ws, source_ws + target_ws).view(target_mesh_shape),
+    )
+
+    is_source = rank < source_ws
+    torch.manual_seed(1000 + rank)
+    if is_source:
+        # Large magnitude so bf16-side reduction loses precision distinctly
+        # from fp32-side reduction.
+        src_local = torch.randn(tensor_shape, dtype=torch.float32, device=device) * 1e3
+        src_dt = DTensor.from_local(src_local, source_mesh, list(source_placements))
+        full_logical_fp32 = src_dt.redistribute(source_mesh, [Replicate()]).to_local()
+        expected_bf16 = full_logical_fp32.to(transfer_dtype)
+        tgt_local = None
+    else:
+        torch.manual_seed(0)
+        tgt_global = torch.zeros(tensor_shape, dtype=transfer_dtype, device=device)
+        tgt_dt = distribute_tensor(tgt_global, target_mesh, list(target_placements))
+        tgt_local = tgt_dt.to_local()
+        expected_bf16 = torch.empty(tensor_shape, dtype=transfer_dtype, device=device)
+
+    if is_source and rank == 0:
+        for tr in range(source_ws, world_size):
+            dist.send(expected_bf16, dst=tr)
+    if not is_source:
+        dist.recv(expected_bf16, src=0)
+
+    m2m_map, src_slicers, tgt_slicers, partial_red = get_m2m_map(
+        source_mesh=source_mesh,
+        source_placements=list(source_placements),
+        target_mesh=target_mesh,
+        target_placements=list(target_placements),
+        group=dist.group.WORLD,
+        device=device,
+    )
+
+    source_ranks_list = list(range(source_ws))
+    source_group = dist.new_group(ranks=source_ranks_list)
+    source_partial_groups = _create_partial_groups(
+        mesh_tensor=source_mesh.mesh,
+        partial_reductions=partial_red,
+        this_rank=rank,
+        full_source_ranks=source_ranks_list,
+        full_source_group=source_group,
+    )
+
+    chunks = map_to_chunk_ops(
+        m2m_map=m2m_map,
+        rank=rank,
+        source_num_slicers=src_slicers,
+        target_num_slicers=tgt_slicers,
+        source_tensor=src_local if is_source else None,
+        target_tensor=tgt_local,
+        transfer_dtype=transfer_dtype,
+        source_partial_groups=source_partial_groups or None,
+    )
+
+    match comm_method:
+        case "chunk":
+            chunk_comm(chunks=chunks)
+        case "bucket":
+            buckets = chunk_to_bucket_ops(chunks=chunks, bucket_size=256 * 1024 * 1024)
+            bucket_comm(buckets=buckets)
+        case _:
+            raise ValueError(f"unknown comm_method: {comm_method}")
+
+    if not is_source:
+        got = tgt_dt.full_tensor()
+        assert got.dtype == transfer_dtype, f"target dtype {got.dtype} != {transfer_dtype}"
+        # bf16 has ~7-bit mantissa; rtol=1e-2 is tight enough that a
+        # cast-first then bf16-reduce path on 1e3-scale inputs would fail.
+        assert torch.allclose(got, expected_bf16, rtol=1e-2, atol=1.0), (
+            f"mixed-dtype partial reshard mismatch on rank {rank}: "
+            f"max diff {(got.float() - expected_bf16.float()).abs().max().item()}"
+        )
+
+    dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("comm_method", ["chunk", "bucket"])
+def test_partial_mixed_dtype(comm_method):
+    source_ws = 4
+    target_ws = 4
+    world_size = source_ws + target_ws
+    tensor_shape = (8, 16)
+
+    os.environ["MASTER_ADDR"] = "localhost"
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        s.listen(1)
+        os.environ["MASTER_PORT"] = str(s.getsockname()[1])
+
+    try:
+        torch.multiprocessing.spawn(
+            _run_partial_mixed_dtype,
+            args=(world_size, source_ws, target_ws, tensor_shape, "cpu", comm_method),
+            nprocs=world_size,
+            join=True,
+        )
+    except Exception as e:
+        pytest.fail(f"mixed-dtype partial reshard failed: {e}")
 
 
 @pytest.mark.parametrize(
@@ -170,8 +377,61 @@ def _run(
             (8, 16, 32),
             True,
         ),
+        # 6. Source Partial (sum) on 1D mesh -> Replicate target (etha collapses
+        # Partial -> Replicate via source-side all-reduce before send).
+        (
+            (4,),
+            (Partial(),),
+            (4,),
+            (Replicate(),),
+            (8, 16),
+            False,
+        ),
+        # 7. Source Partial("avg") on 1D mesh -> Shard target.
+        (
+            (4,),
+            (Partial("avg"),),
+            (4,),
+            (Shard(0),),
+            (8, 16),
+            False,
+        ),
+        # 8. 2D mesh with (Shard(0), Partial()) -> 1D Shard target.
+        # The partial sub-group is per-row (smaller than full source).
+        (
+            (2, 2),
+            (Shard(0), Partial()),
+            (4,),
+            (Shard(0),),
+            (8, 16),
+            False,
+        ),
+        # 9. 2D mesh with double Partial (full-source reduce) -> Replicate.
+        (
+            (2, 2),
+            (Partial(), Partial()),
+            (4,),
+            (Replicate(),),
+            (8, 16),
+            False,
+        ),
+        # 10. Asymmetric 2D Partial-Partial with target smaller than source.
+        # Forces the trace path to drop primaries for source ranks beyond
+        # target_ws, so shadow expansion has to transitively reach every
+        # Partial peer (e.g. rank 5 is only connected via shared sub-groups
+        # with ranks 2,3,4; a non-transitive expand would leave it out and
+        # deadlock the chunk-level reduce on sub-group [3,4,5]).
+        (
+            (2, 3),
+            (Partial(), Partial()),
+            (2,),
+            (Replicate(),),
+            (8, 16),
+            False,
+        ),
     ],
 )
+@pytest.mark.parametrize("comm_method", ["chunk", "bucket"])
 def test_reshard(
     source_mesh_shape,
     source_placements,
@@ -179,6 +439,7 @@ def test_reshard(
     target_placements,
     tensor_shape,
     slice_view,
+    comm_method,
 ):
     source_ws = math.prod(source_mesh_shape)
     target_ws = math.prod(target_mesh_shape)
@@ -202,6 +463,7 @@ def test_reshard(
                 tensor_shape,
                 "cpu",
                 slice_view,
+                comm_method,
             ),
             nprocs=world_size,
             join=True,

--- a/tests/test_communication_symmetric_mesh.py
+++ b/tests/test_communication_symmetric_mesh.py
@@ -60,7 +60,7 @@ def run_test_communication(
 
     # Test: Call get_m2m_map twice with reversed source/target to test for deadlock
     # Direction 1: A -> B
-    m2m_map_a_to_b, source_slicers_a, target_slicers_b = get_m2m_map(
+    m2m_map_a_to_b, source_slicers_a, target_slicers_b, _ = get_m2m_map(
         source_mesh=mesh_a,
         source_placements=specs,
         target_mesh=mesh_b,
@@ -70,7 +70,7 @@ def run_test_communication(
     )
 
     # Direction 2: B -> A (reversed to test deadlock)
-    m2m_map_b_to_a, source_slicers_b, target_slicers_a = get_m2m_map(
+    m2m_map_b_to_a, source_slicers_b, target_slicers_a, _ = get_m2m_map(
         source_mesh=mesh_b,
         source_placements=specs,
         target_mesh=mesh_a,

--- a/tests/test_distributed_model_transfer.py
+++ b/tests/test_distributed_model_transfer.py
@@ -4,10 +4,36 @@ import os
 import time
 import shutil
 import signal
+import socket
 import subprocess
 from pathlib import Path
 
 import pytest
+
+
+def _find_free_port() -> int:
+    """Bind to an OS-assigned ephemeral port, close, return the number.
+
+    There's still a TOCTOU window before the child re-binds, but four parallel
+    ports collide with our long-running agent only when the agent's internal
+    TCPStores grab the same number — picking from the ephemeral range moments
+    before launch is good enough for a test harness.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _find_n_free_ports(n: int) -> tuple[int, ...]:
+    """``_find_free_port`` ``n`` times, with within-call dedup.
+
+    Back-to-back ``bind(0)`` calls *can* return the same port; the kernel makes
+    it rare but does not promise uniqueness. Loop until we have ``n`` distinct.
+    """
+    selected: set[int] = set()
+    while len(selected) < n:
+        selected.add(_find_free_port())
+    return tuple(selected)
 
 
 def _spawn_process(cmd: list[str], env: dict[str, str], cwd: Path, log_path: Path) -> tuple[subprocess.Popen, object]:
@@ -56,18 +82,24 @@ def test_distributed_model_transfer_end_to_end(training_dtype: str, inference_dt
     for candidate in lmdb_root.glob("*"):
         candidate.unlink(missing_ok=True)
 
+    # Pick four free ephemeral ports per case to avoid collisions between cases
+    # (agent's pair-handshake TCPStores grab ephemeral ports — a hard-coded
+    # master-port for the next case can race with them).
+    agent_port, train_port, inference_port, store_port = _find_n_free_ports(4)
+
     base_env = os.environ.copy()
     base_env.setdefault("PIXI_PROJECT_ROOT", str(project_root))
     base_env.setdefault("MASTER_ADDR", "127.0.0.1")
     base_env.setdefault("HF_HOME", "/data/hf")
     base_env.setdefault("HF_HUB_OFFLINE", "1")
+    base_env["ETHA_STORE_PORT"] = str(store_port)
 
     processes: list[tuple[subprocess.Popen, object]] = []
 
     agent_cmd = [
         "torchrun",
         "--nproc_per_node=8",
-        "--master-port=39500",
+        f"--master-port={agent_port}",
         "tests/distributed_model_transfer/agent.py",
     ]
     agent_proc = _spawn_process(agent_cmd, base_env, project_root, agent_log_path)
@@ -83,7 +115,7 @@ def test_distributed_model_transfer_end_to_end(training_dtype: str, inference_dt
     training_cmd = [
         "torchrun",
         "--nproc_per_node=4",
-        "--master-port=39501",
+        f"--master-port={train_port}",
         "tests/distributed_model_transfer/train.py",
     ]
     train_proc = _spawn_process(training_cmd, training_env, project_root, train_log_path)
@@ -97,7 +129,7 @@ def test_distributed_model_transfer_end_to_end(training_dtype: str, inference_dt
     inference_cmd = [
         "torchrun",
         "--nproc_per_node=4",
-        "--master-port=39502",
+        f"--master-port={inference_port}",
         "tests/distributed_model_transfer/inference.py",
     ]
     inference_proc = _spawn_process(inference_cmd, inference_env, project_root, inference_log_path)

--- a/tests/test_partial_chunk_reduce.py
+++ b/tests/test_partial_chunk_reduce.py
@@ -1,0 +1,209 @@
+"""Correctness tests for chunk-level Partial -> Replicate reduce.
+
+These tests exercise the streaming chunk-level reduce implementation in
+isolation, comparing against PyTorch's ``DTensor.redistribute`` ground truth.
+Etha's end-to-end Partial routing (``get_m2m_map`` + shadow expansion + chunk
+pipeline) is covered separately in ``test_communication_replicate_shard``;
+this file focuses on the reduce algorithm itself across corner cases:
+
+* multi-dim meshes (1D / 2D / 3D)
+* mixed ``Shard + Partial`` and double-``Partial`` placements
+* all reduce ops (sum / avg / max / min)
+* fp16 numerical fidelity with random data
+* non-contiguous local tensors
+* chunk size edge cases (> tensor, non-multiple of tensor)
+"""
+
+import os
+import math
+import socket
+import logging
+
+import torch
+import pytest
+import torch.distributed as dist
+from torch.distributed._tensor import Shard, DTensor, Replicate, DeviceMesh
+from torch.distributed.tensor.placement_types import Partial
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+REDUCE_OP_MAP = {
+    "sum": dist.ReduceOp.SUM,
+    "avg": dist.ReduceOp.AVG,
+    "max": dist.ReduceOp.MAX,
+    "min": dist.ReduceOp.MIN,
+}
+
+
+def chunk_level_partial_to_replicate(
+    local_tensor: torch.Tensor,
+    mesh: DeviceMesh,
+    placements: tuple,
+    chunk_numel: int,
+) -> torch.Tensor:
+    """Reduce Partial-dim contributions via chunk-sized streaming all-reduce.
+
+    For each ``Partial`` dim in ``placements``, run an all-reduce on the
+    corresponding mesh sub-group, chunk by chunk. Returns the local tensor
+    with all ``Partial`` dims collapsed to ``Replicate``.
+    """
+    contiguous_local = local_tensor.contiguous()
+    flat_local = contiguous_local.view(-1)
+    n = flat_local.numel()
+
+    reductions = []
+    for mesh_dim, placement in enumerate(placements):
+        if isinstance(placement, Partial):
+            op = REDUCE_OP_MAP[placement.reduce_op]
+            group = mesh.get_group(mesh_dim)
+            reductions.append((group, op))
+
+    if not reductions:
+        return contiguous_local.clone()
+
+    out_flat = torch.empty_like(flat_local)
+    chunk_buf = torch.empty(chunk_numel, dtype=local_tensor.dtype, device=local_tensor.device)
+
+    for start in range(0, n, chunk_numel):
+        end = min(start + chunk_numel, n)
+        size = end - start
+        view = chunk_buf[:size]
+        view.copy_(flat_local[start:end])
+        for group, op in reductions:
+            dist.all_reduce(view, op=op, group=group)
+        out_flat[start:end].copy_(view)
+
+    return out_flat.view_as(contiguous_local)
+
+
+def _compute_local_shape(tensor_shape, mesh_shape, placements):
+    """Per-rank local shape after Shard partitioning (Partial / Replicate keep full shape)."""
+    local = list(tensor_shape)
+    for mesh_dim, p in enumerate(placements):
+        if isinstance(p, Shard):
+            assert local[p.dim] % mesh_shape[mesh_dim] == 0, (
+                f"tensor dim {p.dim}={local[p.dim]} not divisible by mesh dim {mesh_dim}={mesh_shape[mesh_dim]}"
+            )
+            local[p.dim] //= mesh_shape[mesh_dim]
+    return tuple(local)
+
+
+def _run(
+    rank: int,
+    world_size: int,
+    mesh_shape: tuple[int, ...],
+    placements: tuple,
+    tensor_shape: tuple[int, ...],
+    chunk_numel: int,
+    dtype_str: str,
+    non_contiguous: bool,
+):
+    """Build a Partial DTensor, run chunk-level reduce, compare against PyTorch."""
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+    mesh = DeviceMesh("cpu", torch.arange(world_size).view(mesh_shape))
+    dtype = {"fp32": torch.float32, "fp16": torch.float16, "bf16": torch.bfloat16}[dtype_str]
+
+    local_shape = _compute_local_shape(tensor_shape, mesh_shape, placements)
+
+    torch.manual_seed(1000 + rank)
+    if non_contiguous:
+        wide_shape = list(local_shape)
+        wide_shape[-1] *= 2
+        wide = torch.randn(wide_shape, dtype=dtype)
+        local = wide[..., : local_shape[-1] * 2 : 2]
+        assert not local.is_contiguous(), "non-contiguous setup failed"
+    else:
+        local = torch.randn(local_shape, dtype=dtype)
+
+    dt = DTensor.from_local(local, mesh, list(placements))
+    target_placements = [Replicate() if isinstance(p, Partial) else p for p in placements]
+    truth = dt.redistribute(mesh, target_placements).to_local()
+
+    result = chunk_level_partial_to_replicate(local, mesh, placements, chunk_numel)
+
+    # Low-precision dtypes accumulate differently under chunked vs full reduce
+    # because the backend picks reduction order per tensor size. Tolerances
+    # are set to the natural ULP scale near typical sum magnitudes (bf16 has
+    # only 7 mantissa bits, so ULP near sums of N(0,1) values is ~3e-2).
+    if dtype == torch.float16:
+        rtol, atol = 5e-3, 5e-3
+    elif dtype == torch.bfloat16:
+        rtol, atol = 5e-2, 5e-2
+    else:
+        rtol, atol = 1e-5, 1e-5
+
+    max_diff = (result.float() - truth.float()).abs().max().item()
+    assert torch.allclose(result, truth, rtol=rtol, atol=atol), (
+        f"rank {rank}: chunk-level diverges from DTensor.redistribute; max diff = {max_diff} "
+        f"(rtol={rtol}, atol={atol}, dtype={dtype_str}, placements={placements}, chunk={chunk_numel})"
+    )
+
+    dist.destroy_process_group()
+
+
+_CASES = [
+    # === 1D mesh, single Partial, each reduce op ===
+    ((4,), (Partial("sum"),), (8, 16), 32, "fp32", False),
+    ((4,), (Partial("avg"),), (8, 16), 32, "fp32", False),
+    ((4,), (Partial("max"),), (8, 16), 32, "fp32", False),
+    ((4,), (Partial("min"),), (8, 16), 32, "fp32", False),
+    # === 2D mesh, Partial combined with other placements ===
+    ((2, 2), (Replicate(), Partial()), (8, 16), 32, "fp32", False),
+    ((2, 2), (Partial(), Replicate()), (8, 16), 32, "fp32", False),
+    # Shard + Partial -- the key correctness corner case
+    ((2, 2), (Shard(0), Partial()), (8, 16), 32, "fp32", False),
+    ((2, 2), (Partial(), Shard(0)), (8, 16), 32, "fp32", False),
+    ((2, 2), (Shard(1), Partial()), (8, 16), 32, "fp32", False),
+    # Double Partial -- reduce on both mesh dims
+    ((2, 2), (Partial(), Partial()), (8, 16), 32, "fp32", False),
+    ((2, 2), (Partial("avg"), Partial("avg")), (8, 16), 32, "fp32", False),
+    # === 3D mesh, mixed (mirrors the trainer MoE shape used elsewhere) ===
+    ((1, 2, 2), (Replicate(), Partial(), Shard(0)), (8, 16), 32, "fp32", False),
+    ((2, 2, 2), (Shard(0), Partial(), Replicate()), (16, 32), 64, "fp32", False),
+    # === Dtype + numerical fidelity (random data forces accumulation error) ===
+    ((4,), (Partial(),), (64, 64), 64, "fp16", False),
+    ((4,), (Partial(),), (64, 64), 64, "bf16", False),
+    ((4,), (Partial("avg"),), (64, 64), 64, "fp16", False),
+    # === Non-contiguous local tensor ===
+    ((4,), (Partial(),), (8, 16), 32, "fp32", True),
+    ((2, 2), (Shard(0), Partial()), (8, 16), 32, "fp32", True),
+    # === Chunk size edge cases ===
+    ((4,), (Partial(),), (8, 16), 1024, "fp32", False),  # chunk > tensor
+    ((4,), (Partial(),), (10, 13), 7, "fp32", False),  # non-multiple
+    ((4,), (Partial(),), (3, 5), 1, "fp32", False),  # chunk = 1
+]
+
+
+@pytest.mark.parametrize(
+    "mesh_shape, placements, tensor_shape, chunk_numel, dtype_str, non_contiguous",
+    _CASES,
+)
+def test_partial_chunk_reduce(mesh_shape, placements, tensor_shape, chunk_numel, dtype_str, non_contiguous):
+    """Chunk-level reduce must agree with DTensor.redistribute Partial -> Replicate."""
+    world_size = math.prod(mesh_shape)
+
+    os.environ["MASTER_ADDR"] = "localhost"
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        s.listen(1)
+        os.environ["MASTER_PORT"] = str(s.getsockname()[1])
+
+    try:
+        torch.multiprocessing.spawn(
+            _run,
+            args=(
+                world_size,
+                mesh_shape,
+                placements,
+                tensor_shape,
+                chunk_numel,
+                dtype_str,
+                non_contiguous,
+            ),
+            nprocs=world_size,
+            join=True,
+        )
+    except Exception as e:
+        pytest.fail(f"chunk-level reduce test failed: {e}")


### PR DESCRIPTION
## What did you do

Replace the ``NotImplementedError`` from PR #97 with a real implementation: source ``Partial`` placements now flow through the M2M routing + chunk pipeline. Target ``Partial`` is still rejected (cross-PG decomposition isn't well-defined).

**Design (after a few wrong turns; see ``bench/partial_reduce_prototype.py`` for the data)**:

1. **Hand-rolled routing for Partial source** (in ``get_m2m_map``): when source placements contain Partial, we skip the DTensor-encoding/full_tensor routing trace (which collapses Replicate-equivalent peers down to one rank) and compute the m2m_map deterministically from mesh + placements. Each Partial sub-group's (cell, target_owner) ship slots are round-robin assigned to sub-group members so every source rank gets a unique ship task -- no shadow chunks, no redundant transfers, load balanced across peers.

2. **Whole-tensor reduce before chunking** (in ``agent._handle_transfer``'s ``register_tensors`` path): for each source-Partial pair, clone the user's local Partial buffer and run an all-reduce on each Partial sub-group; chunks then point at the reduced buffer. The clone survives in ``BatchState.pair_reduced_sources`` until transfer completes.

   We tried chunk-level reduce first. It's mathematically incorrect for mixed Shard+Partial: peers ship different cells, so reducing their chunk buffers in a single collective mixes different logical positions across peers. The fix would require shadow-chunk participation from non-shipping peers; for Phase 1 we accept the +1x tensor memory cost and leave shadow-chunk optimization to a follow-up.

3. **NCCL sub-group creation** (in ``agent._handle_init_pair``): for each Partial mesh dim, create the corresponding source-side NCCL sub-group via ``get_or_create_process_group`` (cached). Reuses ``local_group`` when the sub-group spans the entire source side (the common 1D-mesh case), avoiding a redundant new_group bootstrap.

**API changes**:
- ``get_m2m_map`` returns a 4-tuple now; the new ``source_partial_reductions: list[(mesh_dim_idx, reduce_op_str)]`` lets callers know which dims need a sub-group reduce. All callers in this PR are updated.
- ``M2MMap`` / ``PairState`` / ``BatchState`` extended with corresponding fields.
- ``init_pair`` docstring + README + ``docs/index.md`` updated to say Partial is supported on the source side.

## New test cases

- ``tests/test_communication_replicate_shard.py``: 4 new Partial cases (1D Partial → Replicate / Shard, 2D Shard+Partial, double Partial), exercising the full chunk pipeline through ``chunk_comm``.
- ``tests/test_partial_chunk_reduce.py`` (new, 21 cases): mesh ndim × reduce_op × dtype × non-contiguous × chunk-size edge sweep, validating Partial-reduce correctness against PyTorch's ``DTensor.redistribute`` ground truth.
- All existing reshard tests still pass (5 + 1 + 11 + 21 + 4 = **42 tests pass**).

## Test results

```
$ pixi run -e dev pytest tests/test_communication_*.py tests/test_partial_chunk_reduce.py --timeout=120
42 passed in 368.40s
```

ruff format + ruff check clean; pre-commit hooks pass.

## Other comments

- ``NotImplementedError`` is still raised in two known sub-cases (Phase 2 followups):
  - Target ``Partial`` (rejected by design)
  - Over-sharded Partial sub-group where ``cells * target_owners < sub_group_size`` (rare in practice)
- Cross-node perf data (``bench/partial_reduce_prototype.py``) shows the design trade-offs that motivated this approach. Chunk-overlap optimization (where reduce/send overlap on independent NVLink/IB paths) is left for a follow-up issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for "Partial" placement strategy in cross-process-group tensor redistribution with automatic source-side reduction.
  * Enhanced benchmarking with support for Partial configurations and improved baseline handling.

* **Bug Fixes**
  * Fixed hardcoded port configuration in distributed tests to use environment variables.

* **Documentation**
  * Updated documentation to clarify how Partial placements are handled across process groups.

* **Tests**
  * Added comprehensive test coverage for Partial-to-Replicate reduction including mixed placements and edge cases.

* **Chores**
  * Updated project gitignore patterns.
  * Added Transformers dependency to development environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cmriat/Etha/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->