### PR TITLE
refactor(comm): typed Route list for m2m routing (#99)

### DIFF
--- a/bench/transfer_benchmark.py
+++ b/bench/transfer_benchmark.py
@@ -707,7 +707,7 @@ def main():
                         target_local_tensor = target_local_tensors[i]
 
                     chunks = map_to_chunk_ops(
-                        m2m_map=m2m_map,
+                        routes=m2m_map,
                         rank=rank,
                         source_num_slicers=source_num_slicers,
                         target_num_slicers=target_num_slicers,

--- a/src/etha/comm/get_chunks.py
+++ b/src/etha/comm/get_chunks.py
@@ -3,7 +3,7 @@
 import torch
 import torch.distributed as dist
 
-from .ir import Chunk, TransferType
+from .ir import Chunk, Route, TransferType
 from .utils import (
     get_slicer_tuples,
     get_slice_from_multi_index,
@@ -22,7 +22,7 @@ def calculate_chunk_shape(
 
 
 def map_to_chunk_ops(
-    m2m_map: dict[int, dict[tuple, list[tuple[int, tuple]]]],
+    routes: list[Route],
     rank: int,
     source_num_slicers: list[int],
     target_num_slicers: list[int],
@@ -31,7 +31,7 @@ def map_to_chunk_ops(
     transfer_dtype: torch.dtype | None = None,
     source_partial_groups: list[tuple[dist.ProcessGroup, str]] | None = None,
 ) -> list[Chunk]:
-    if not m2m_map:
+    if not routes:
         return []
     source_tensor_shape = source_tensor.shape if source_tensor is not None else None
     target_tensor_shape = target_tensor.shape if target_tensor is not None else None
@@ -47,85 +47,81 @@ def map_to_chunk_ops(
         target_slicer_tuples = get_slicer_tuples(target_tensor_shape, target_num_slicers_extended)
     broadcast_groups = set()
 
-    for src_rank, src_map in m2m_map.items():
-        for _, dst_list in src_map.items():
-            if len(dst_list) > 1:
-                group_ranks = (src_rank,) + tuple(sorted({r for r, _ in dst_list}))
-                broadcast_groups.add(group_ranks)
+    for route in routes:
+        if route.kind == TransferType.BROADCAST:
+            group_ranks = (route.src.rank,) + tuple(sorted({d.rank for d in route.dsts}))
+            broadcast_groups.add(group_ranks)
     for group_ranks in sorted(broadcast_groups):
         get_or_create_process_group(list(group_ranks))
 
     chunks: list[Chunk] = []
-    for src_rank, src_map in m2m_map.items():
-        for src_idx, dst_list in src_map.items():
-            if not dst_list:
-                # Partial sub-group member with no ship task — joins reduce only.
-                transfer_type = TransferType.SHADOW
-            elif len(dst_list) > 1:
-                transfer_type = TransferType.BROADCAST
-            else:
-                transfer_type = TransferType.P2P
-            dst_ranks: tuple[int, ...] = tuple(sorted({r for r, _ in dst_list}))
-            if src_rank == rank:
-                src_slice_tuples: tuple[slice, ...] = ()
-                if source_slicer_tuples is not None and source_num_slicers_extended is not None:
-                    src_slice_tuples = get_slice_from_multi_index(
-                        src_idx, source_num_slicers_extended, source_slicer_tuples
-                    )
-
-                chunks.append(
-                    Chunk(
-                        chunk_shape=calculate_chunk_shape(source_num_slicers_extended, source_tensor_shape),
-                        transfer_type=transfer_type,
-                        is_source=True,
-                        src_rank=rank,
-                        src_idx=src_idx,
-                        dst_ranks=dst_ranks,
-                        slice_tuples=src_slice_tuples,
-                        tensor=source_tensor,
-                        transfer_dtype=transfer_dtype,
-                        source_partial_groups=source_partial_groups,
-                    )
+    for route in routes:
+        src_rank = route.src.rank
+        src_idx = route.src.cell
+        transfer_type = route.kind
+        dst_ranks: tuple[int, ...] = tuple(sorted({d.rank for d in route.dsts}))
+        if src_rank == rank:
+            src_slice_tuples: tuple[slice, ...] = ()
+            if source_slicer_tuples is not None and source_num_slicers_extended is not None:
+                src_slice_tuples = get_slice_from_multi_index(
+                    src_idx, source_num_slicers_extended, source_slicer_tuples
                 )
-            for dst_rank, dst_idx in dst_list:
-                if dst_rank == rank:
-                    if src_rank == rank:
-                        actual_transfer_type = TransferType.SELF_COPY
-                    else:
-                        actual_transfer_type = transfer_type
-                    dst_slice_tuples: tuple[slice, ...] = ()
-                    if target_slicer_tuples is not None and target_num_slicers_extended is not None:
-                        dst_slice_tuples = get_slice_from_multi_index(
-                            dst_idx, target_num_slicers_extended, target_slicer_tuples
+
+            chunks.append(
+                Chunk(
+                    chunk_shape=calculate_chunk_shape(source_num_slicers_extended, source_tensor_shape),
+                    transfer_type=transfer_type,
+                    is_source=True,
+                    src_rank=rank,
+                    src_idx=src_idx,
+                    dst_ranks=dst_ranks,
+                    slice_tuples=src_slice_tuples,
+                    tensor=source_tensor,
+                    transfer_dtype=transfer_dtype,
+                    source_partial_groups=source_partial_groups,
+                )
+            )
+        for dst in route.dsts:
+            dst_rank = dst.rank
+            dst_idx = dst.cell
+            if dst_rank == rank:
+                if src_rank == rank:
+                    actual_transfer_type = TransferType.SELF_COPY
+                else:
+                    actual_transfer_type = transfer_type
+                dst_slice_tuples: tuple[slice, ...] = ()
+                if target_slicer_tuples is not None and target_num_slicers_extended is not None:
+                    dst_slice_tuples = get_slice_from_multi_index(
+                        dst_idx, target_num_slicers_extended, target_slicer_tuples
+                    )
+                if actual_transfer_type == TransferType.SELF_COPY:
+                    chunks.append(
+                        Chunk(
+                            chunk_shape=calculate_chunk_shape(target_num_slicers_extended, target_tensor_shape),
+                            transfer_type=actual_transfer_type,
+                            is_source=True,
+                            src_rank=src_rank,
+                            src_idx=src_idx,
+                            dst_ranks=dst_ranks,
+                            dst_idx=dst_idx,
+                            slice_tuples=dst_slice_tuples,
+                            src_slice_tuples=src_slice_tuples,
+                            tensor=target_tensor,
                         )
-                    if actual_transfer_type == TransferType.SELF_COPY:
-                        chunks.append(
-                            Chunk(
-                                chunk_shape=calculate_chunk_shape(target_num_slicers_extended, target_tensor_shape),
-                                transfer_type=actual_transfer_type,
-                                is_source=True,
-                                src_rank=src_rank,
-                                src_idx=src_idx,
-                                dst_ranks=dst_ranks,
-                                dst_idx=dst_idx,
-                                slice_tuples=dst_slice_tuples,
-                                src_slice_tuples=src_slice_tuples,
-                                tensor=target_tensor,
-                            )
+                    )
+                else:
+                    chunks.append(
+                        Chunk(
+                            chunk_shape=calculate_chunk_shape(target_num_slicers_extended, target_tensor_shape),
+                            transfer_type=actual_transfer_type,
+                            is_source=False,
+                            src_rank=src_rank,
+                            src_idx=src_idx,
+                            dst_ranks=dst_ranks,
+                            dst_idx=dst_idx,
+                            slice_tuples=dst_slice_tuples,
+                            tensor=target_tensor,
+                            transfer_dtype=transfer_dtype,
                         )
-                    else:
-                        chunks.append(
-                            Chunk(
-                                chunk_shape=calculate_chunk_shape(target_num_slicers_extended, target_tensor_shape),
-                                transfer_type=actual_transfer_type,
-                                is_source=False,
-                                src_rank=src_rank,
-                                src_idx=src_idx,
-                                dst_ranks=dst_ranks,
-                                dst_idx=dst_idx,
-                                slice_tuples=dst_slice_tuples,
-                                tensor=target_tensor,
-                                transfer_dtype=transfer_dtype,
-                            )
-                        )
+                    )
     return chunks

--- a/src/etha/comm/get_m2m_map.py
+++ b/src/etha/comm/get_m2m_map.py
@@ -17,11 +17,10 @@ logger = logging.getLogger(__name__)
 
 
 def _dict_to_routes(m2m_map: dict[int, dict[tuple, list[tuple[int, tuple]]]]) -> list[Route]:
-    """Materialize the nested build dict into a canonical list of Routes.
+    """Materialize the build dict into a canonical list of Routes.
 
     Sorted by ``(src_rank, cell)`` so every rank produces the same order — the
-    lock-step contract that chunk-level NCCL collectives (Partial reduce) rely
-    on. ``kind`` is classified here, once: empty dsts -> SHADOW, >1 -> BROADCAST.
+    lock-step contract chunk-level NCCL collectives (Partial reduce) rely on.
     """
     routes: list[Route] = []
     for src_rank in sorted(m2m_map):
@@ -111,8 +110,8 @@ def _expand_partial_shadows(
                 if r != src_rank:
                     expanded.setdefault(r, {}).setdefault(cell, [])
 
-    # Sort cells so all component members iterate in lock-step.
-    return {r: {cell: expanded[r][cell] for cell in sorted(expanded[r].keys())} for r in expanded}
+    # Cell ordering is enforced in _dict_to_routes; don't re-sort here.
+    return expanded
 
 
 def get_m2m_map(

--- a/src/etha/comm/get_m2m_map.py
+++ b/src/etha/comm/get_m2m_map.py
@@ -10,9 +10,32 @@ import torch.distributed as dist
 from torch.distributed._tensor import Shard, Replicate, DeviceMesh, distribute_tensor
 from torch.distributed.tensor.placement_types import Partial, Placement
 
+from .ir import Route, Endpoint, TransferType
 from .utils import enumerate_partial_subgroup_ranks
 
 logger = logging.getLogger(__name__)
+
+
+def _dict_to_routes(m2m_map: dict[int, dict[tuple, list[tuple[int, tuple]]]]) -> list[Route]:
+    """Materialize the nested build dict into a canonical list of Routes.
+
+    Sorted by ``(src_rank, cell)`` so every rank produces the same order — the
+    lock-step contract that chunk-level NCCL collectives (Partial reduce) rely
+    on. ``kind`` is classified here, once: empty dsts -> SHADOW, >1 -> BROADCAST.
+    """
+    routes: list[Route] = []
+    for src_rank in sorted(m2m_map):
+        cells = m2m_map[src_rank]
+        for cell in sorted(cells):
+            dsts = tuple(Endpoint(rank=r, cell=c) for r, c in cells[cell])
+            if not dsts:
+                kind = TransferType.SHADOW
+            elif len(dsts) > 1:
+                kind = TransferType.BROADCAST
+            else:
+                kind = TransferType.P2P
+            routes.append(Route(src=Endpoint(rank=src_rank, cell=cell), dsts=dsts, kind=kind))
+    return routes
 
 
 def _get_tensor_ndim(placements: tuple[Placement, ...]) -> int:
@@ -100,7 +123,7 @@ def get_m2m_map(
     group: dist.ProcessGroup,
     device: str = "cpu",
 ) -> tuple[
-    dict[int, dict[tuple, list[tuple[int, tuple]]]],
+    list[Route],
     list[int],
     list[int],
     list[tuple[int, str]],
@@ -114,7 +137,7 @@ def get_m2m_map(
     across an independent process-group boundary.
 
     Returns:
-        ``(m2m_map, source_num_slicers, target_num_slicers, source_partial_reductions)``.
+        ``(routes, source_num_slicers, target_num_slicers, source_partial_reductions)``.
         The last is a list of ``(mesh_dim_idx, reduce_op_str)`` per Partial dim,
         empty when source has no Partial.
     """
@@ -239,4 +262,6 @@ def get_m2m_map(
 
     final_m2m_map = _expand_partial_shadows(final_m2m_map, source_mesh, source_placements)
 
-    return final_m2m_map, source_num_slicers, target_num_slicers, source_partial_reductions
+    routes = _dict_to_routes(final_m2m_map)
+
+    return routes, source_num_slicers, target_num_slicers, source_partial_reductions

--- a/src/etha/comm/ir.py
+++ b/src/etha/comm/ir.py
@@ -13,24 +13,18 @@ logger = logging.getLogger(__name__)
 
 
 class Endpoint(msgspec.Struct, frozen=True):
-    """One chunk location: a rank and its cell coordinate in the transfer grid.
-
-    ``cell`` is the multi-dimensional index of the chunk within that rank's
-    local shard (fed to ``get_slice_from_multi_index`` to get the byte slice).
-    Leaf data (int + tuple of ints), so no reference cycles.
-    """
+    """A chunk location: a rank and its cell (multi-index) in the transfer grid."""
 
     rank: int
     cell: tuple[int, ...]
 
 
 class Route(msgspec.Struct, frozen=True):
-    """One source cell's delivery plan: ``src`` endpoint to a set of ``dsts``.
+    """One source cell's delivery: ``src`` endpoint to a set of dst endpoints.
 
-    ``kind`` is the route-level classification, set once at construction:
-    SHADOW (empty ``dsts``, reduce-only), BROADCAST (>1 dst), or P2P (1 dst).
-    SELF_COPY is not a route kind — it is refined per-dst at execution when a
-    dst lands on the source rank.
+    ``kind`` is fixed at construction: empty ``dsts`` -> SHADOW (reduce-only),
+    else BROADCAST (>1) or P2P (1). SELF_COPY is not a route kind; it is refined
+    per-dst at execution when a dst lands on the source rank.
     """
 
     src: Endpoint

--- a/src/etha/comm/ir.py
+++ b/src/etha/comm/ir.py
@@ -4,11 +4,39 @@ import logging
 from dataclasses import field, dataclass
 
 import torch
+import msgspec
 import torch.distributed as dist
 
 from .transfer import Transferable, TransferType
 
 logger = logging.getLogger(__name__)
+
+
+class Endpoint(msgspec.Struct, frozen=True):
+    """One chunk location: a rank and its cell coordinate in the transfer grid.
+
+    ``cell`` is the multi-dimensional index of the chunk within that rank's
+    local shard (fed to ``get_slice_from_multi_index`` to get the byte slice).
+    Leaf data (int + tuple of ints), so no reference cycles.
+    """
+
+    rank: int
+    cell: tuple[int, ...]
+
+
+class Route(msgspec.Struct, frozen=True):
+    """One source cell's delivery plan: ``src`` endpoint to a set of ``dsts``.
+
+    ``kind`` is the route-level classification, set once at construction:
+    SHADOW (empty ``dsts``, reduce-only), BROADCAST (>1 dst), or P2P (1 dst).
+    SELF_COPY is not a route kind — it is refined per-dst at execution when a
+    dst lands on the source rank.
+    """
+
+    src: Endpoint
+    dsts: tuple[Endpoint, ...]
+    kind: TransferType
+
 
 _REDUCE_OP_MAP = {
     "sum": dist.ReduceOp.SUM,

--- a/src/etha/tensor_bus/agent.py
+++ b/src/etha/tensor_bus/agent.py
@@ -364,11 +364,11 @@ class TensorBusAgent:
                     f"(first side has Partial placement; cross-PG Partial target is not supported)"
                 )
 
-            def _wrap(m, srcs, tgts, partial_red):
-                if m is None:
+            def _wrap(routes, srcs, tgts, partial_red):
+                if routes is None:
                     return None
                 return M2MMap(
-                    m2m_map=m,
+                    routes=routes,
                     source_num_slicers=srcs,
                     target_num_slicers=tgts,
                     source_partial_reductions=partial_red,
@@ -663,7 +663,7 @@ class TensorBusAgent:
 
                     if pair_state.m2m_send is not None:
                         send_chunks = map_to_chunk_ops(
-                            m2m_map=pair_state.m2m_send.m2m_map,
+                            routes=pair_state.m2m_send.routes,
                             rank=self.rank,
                             source_num_slicers=pair_state.m2m_send.source_num_slicers,
                             target_num_slicers=pair_state.m2m_send.target_num_slicers,
@@ -676,7 +676,7 @@ class TensorBusAgent:
 
                     if pair_state.m2m_recv is not None:
                         recv_chunks = map_to_chunk_ops(
-                            m2m_map=pair_state.m2m_recv.m2m_map,
+                            routes=pair_state.m2m_recv.routes,
                             rank=self.rank,
                             source_num_slicers=pair_state.m2m_recv.source_num_slicers,
                             target_num_slicers=pair_state.m2m_recv.target_num_slicers,

--- a/src/etha/tensor_bus/pair_state.py
+++ b/src/etha/tensor_bus/pair_state.py
@@ -3,14 +3,16 @@
 import msgspec
 import torch.distributed as dist
 
+from etha.comm.ir import Route
+
 
 class M2MMap(msgspec.Struct):
-    """Mesh to mesh topology using M2MMap (shape-independent).
+    """Mesh to mesh topology (shape-independent).
 
-    M2MMap structure: dict[src_rank, dict[src_idx, list[tuple[dst_rank, dst_idx]]]]
+    ``routes`` is a flat list of per-cell delivery plans; see ``comm.ir.Route``.
     """
 
-    m2m_map: dict[int, dict[tuple, list[tuple[int, tuple]]]] | None = None
+    routes: list[Route] | None = None
     source_num_slicers: list[int] | None = None  # How source tensor is partitioned
     target_num_slicers: list[int] | None = None  # How target tensor is partitioned
     # Partial placements found on the source mesh, as (mesh_dim_idx, reduce_op).

--- a/tests/test_communication_cpu.py
+++ b/tests/test_communication_cpu.py
@@ -73,7 +73,7 @@ def run_test_communication(
         logger.info(f"Generated m2m map: {m2m_map}")
     # Step 2: Generate execution-ready chunks directly
     chunks = map_to_chunk_ops(
-        m2m_map=m2m_map,
+        routes=m2m_map,
         rank=rank,
         source_num_slicers=source_num_slicers,
         target_num_slicers=target_num_slicers,
@@ -90,7 +90,7 @@ def run_test_communication(
     target_dist_tensor_bucket = distribute_tensor(target_origin_tensor_bucket, target_mesh, target_specs)
     target_local_bucket = target_dist_tensor_bucket.to_local()
     bucket_chunks = map_to_chunk_ops(
-        m2m_map=m2m_map,
+        routes=m2m_map,
         rank=rank,
         source_num_slicers=source_num_slicers,
         target_num_slicers=target_num_slicers,

--- a/tests/test_communication_replicate_shard.py
+++ b/tests/test_communication_replicate_shard.py
@@ -142,7 +142,7 @@ def _run(
     )
 
     chunks = map_to_chunk_ops(
-        m2m_map=m2m_map,
+        routes=m2m_map,
         rank=rank,
         source_num_slicers=src_slicers,
         target_num_slicers=tgt_slicers,
@@ -273,7 +273,7 @@ def _run_partial_mixed_dtype(
     )
 
     chunks = map_to_chunk_ops(
-        m2m_map=m2m_map,
+        routes=m2m_map,
         rank=rank,
         source_num_slicers=src_slicers,
         target_num_slicers=tgt_slicers,

--- a/tests/test_communication_symmetric_mesh.py
+++ b/tests/test_communication_symmetric_mesh.py
@@ -85,7 +85,7 @@ def run_test_communication(
     if is_in_mesh_a:
         # Mesh A sends to Mesh B
         chunks = map_to_chunk_ops(
-            m2m_map=m2m_map_a_to_b,
+            routes=m2m_map_a_to_b,
             rank=rank,
             source_num_slicers=source_slicers_a,
             target_num_slicers=target_slicers_b,
@@ -95,7 +95,7 @@ def run_test_communication(
     else:
         # Mesh B receives from Mesh A
         chunks = map_to_chunk_ops(
-            m2m_map=m2m_map_a_to_b,
+            routes=m2m_map_a_to_b,
             rank=rank,
             source_num_slicers=source_slicers_a,
             target_num_slicers=target_slicers_b,


### PR DESCRIPTION
## What did you do
Refactor the m2m routing data structure (part of #99). Replace the three-level positional dict `dict[int, dict[tuple, list[tuple[int, tuple]]]]` with a flat `list[Route]`, where each `Route` holds a named `src`/`dsts` of `Endpoint(rank, cell)` and an explicit `kind: TransferType`.

- **Named fields** (#99 problem 1): no more positional `[0][0]` / `(dst_rank, dst_idx)` unpacking.
- **Explicit SHADOW** (#99 problem 2): `Route.kind` is set once at construction (empty `dsts` -> SHADOW) instead of being inferred from an empty list inside `map_to_chunk_ops`.
- **Documented cell ordering** (#99 problem 5): cells are sorted once in `_dict_to_routes` by `(src_rank, cell)`, making the lock-step contract for chunk-level NCCL collectives explicit (and letting `_expand_partial_shadows` drop its own redundant sort).

`Endpoint`/`Route` live in `comm/ir.py` as frozen `msgspec.Struct`, consistent with the existing `M2MMap`/`PairState`. Routes are materialized **locally** after `all_gather_object` merges the build dict, so nothing new crosses the wire.

### Behavior vs. API
Runtime behavior is preserved for all internal call sites (same chunks produced; existing suites green). This is **not** API-preserving — two exported functions change signature:
- `get_m2m_map(...)` first return element: `dict[...]` -> `list[Route]`.
- `map_to_chunk_ops(...)` first kwarg: `m2m_map=` -> `routes=`.

Migration: pass the `list[Route]` from `get_m2m_map` as `routes=`. We deliberately do **not** add a back-compat alias — the repo avoids compatibility shims, and an alias would only mask the kwarg while the value type changes anyway.

**Out of scope / deferred:** target-indexed view (#99 problem 3) and per-rank local views to cut memory (#99 problem 4); the latter is coupled to the collective broadcast-group creation in `map_to_chunk_ops` and needs its own change.

## New test cases
None — behavior-preserving at runtime; existing suites cover the paths.

## Test results
`pytest tests/test_communication_cpu.py tests/test_communication_symmetric_mesh.py tests/test_communication_replicate_shard.py tests/test_partial_chunk_reduce.py` -> **55 passed**.

## Other comments
`source_partial_reductions` (the `list[tuple[int, str]]` return element) still uses a positional tuple — same smell, but out of #99's scope.