### PR TITLE
chore(bench): harden benchmark launcher + document core verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,28 @@
-- run with pixi run
+# Etha
+
+Run everything with `pixi run`. `dev` and `vllm` both define a `submit` task, so the
+env flag is mandatory: `pixi run -e dev <task>`.
+
+## Verifying changes to `src/etha/comm/` or `src/etha/tensor_bus/`
+
+Unit tests only cover disjoint-mesh CPU paths — run all three layers:
+
+1. Unit tests (CPU/gloo, ~9 min):
+   ```
+   pixi run -e dev pytest tests/test_communication_cpu.py \
+     tests/test_communication_symmetric_mesh.py \
+     tests/test_communication_replicate_shard.py tests/test_partial_chunk_reduce.py
+   ```
+2. Transfer benchmark (GPU/NCCL): `pixi run -e dev submit bench/run_benchmark.sh`.
+   Quick single-node check (P2P/BROADCAST/SHADOW paths):
+   ```
+   ETHA_BENCH_SMOKE=1 pixi run -e dev torchrun --nnodes=1 --nproc-per-node=8 \
+     --master-addr=localhost --master-port=29555 ./bench/transfer_benchmark.py
+   ```
+3. vLLM weight-sync example (8 GPUs, the only end-to-end production-path check):
+   `pixi run -e vllm vllm_weight_sync`. Set `HF_HOME=/data/hf` (cached 30B model).
+   Long-running — monitor under an agent, not inline.
+
+Gotchas:
+- vLLM env build failing with `Permission denied` in `.pixi/build/work/`: a stale
+  read-only git checkout — `chmod -R u+w .pixi/build/work/vllm-*` then retry.

--- a/bench/run_benchmark.sh
+++ b/bench/run_benchmark.sh
@@ -5,12 +5,16 @@
 #SBATCH --ntasks=2
 #SBATCH --time=1:00:00
 
+# Surface a torchrun crash instead of exiting 0 + "Benchmark completed".
+# Diagnostics below use ${VAR:-} so unset SLURM vars don't trip -u.
+set -euo pipefail
+
 # Job information
 echo "============================================"
-echo "Job ID: ${SLURM_JOB_ID}"
-echo "Node list: ${SLURM_JOB_NODELIST}"
-echo "Node ID: ${SLURM_NODEID}"
-echo "Task ID: ${SLURM_ARRAY_TASK_ID}"
+echo "Job ID: ${SLURM_JOB_ID:-}"
+echo "Node list: ${SLURM_JOB_NODELIST:-}"
+echo "Node ID: ${SLURM_NODEID:-}"
+echo "Task ID: ${SLURM_ARRAY_TASK_ID:-}"
 echo "============================================"
 
 # NCCL configuration for distributed training
@@ -24,7 +28,9 @@ export NCCL_NCHANNELS_PER_NET_PEER=4
 # Distributed training environment variables
 export NODE_RANK=${JOB_COMPLETION_INDEX}
 export MASTER_ADDR=${SLURM_JOB_FIRST_NODE_IP}
-export MASTER_PORT=23456
+# Per-allocation port (avoids EADDRINUSE from a stale process on a fixed port).
+# cksum is deterministic and MASTER_ADDR is identical across nodes, so all ranks agree.
+export MASTER_PORT=$(( 20000 + $(printf '%s' "${MASTER_ADDR}" | cksum | cut -d' ' -f1) % 20000 ))
 
 echo "Node rank: ${NODE_RANK}"
 echo "Master address: ${MASTER_ADDR}"


### PR DESCRIPTION
## What did you do
Two independent fixes that surfaced while verifying #101 on real GPUs. No production code touched.

**`bench/run_benchmark.sh` — two latent bugs:**
1. **Failure masking** — no `set -e`, so a `torchrun` crash still exited 0 and printed "Benchmark completed", making SLURM report a hard failure as success. Now `set -euo pipefail`; diagnostic echoes use `${VAR:-}` so unset SLURM vars (e.g. `SLURM_ARRAY_TASK_ID` on a non-array job) don't trip `-u`.
2. **Hardcoded `MASTER_PORT=23456`** — collides with any stale process still holding the port (`EADDRINUSE` at rendezvous; observed once during verification). Now derived from `MASTER_ADDR` via `cksum`: deterministic and identical across nodes (all ranks agree on the same port), but varies per allocation.

**`CLAUDE.md`** — document the three-layer verification required for changes under `src/etha/comm/` and `src/etha/tensor_bus/` (unit tests / GPU transfer benchmark / vLLM weight-sync example), since unit tests only cover disjoint-mesh CPU paths and miss the production routing path.

## New test cases
None — this is build/CI tooling + docs, no library code.

## Test results
- `zsh -n bench/run_benchmark.sh` passes; port derivation verified deterministic and node-consistent (same `MASTER_ADDR` → same port; different IP → different port); `${VAR:-}` confirmed not to trip `set -u`.
- The fixed launcher was used to run the full benchmark on 2 nodes × 8 GPUs: rendezvous passed (no `EADDRINUSE`), all 3 placement configs swept, sane bandwidths, zero errors.

## Other comments
Split out of #101 to keep that PR a pure behavior-preserving refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded operational guide with detailed task execution instructions, verification procedures for code changes, and troubleshooting guidance for common issues.

* **Bug Fixes**
  * Enhanced benchmark script robustness with improved error handling, port collision prevention for distributed jobs, and better diagnostic information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cmriat/Etha/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->