### PR TITLE
refactor(comm): split transfer role from transport

### DIFF
--- a/src/etha/comm/get_buckets.py
+++ b/src/etha/comm/get_buckets.py
@@ -29,14 +29,14 @@ def _build_bucket(
 ) -> Bucket:
     first_chunk = entries[0].chunk
     device = first_chunk.tensor.device
-    transfer_type = first_chunk.transfer_type
     dst_ranks = first_chunk.dst_ranks
     src_rank = first_chunk.src_rank
     total_bytes = entries[-1].offset + entries[-1].nbytes
     key = first_chunk.bucket_key
     return Bucket(
-        transfer_type=transfer_type,
+        transport=first_chunk.transport,
         is_source=first_chunk.is_source,
+        is_target=first_chunk.is_target,
         dst_ranks=dst_ranks,
         src_rank=src_rank,
         device=device,

--- a/src/etha/comm/get_chunks.py
+++ b/src/etha/comm/get_chunks.py
@@ -3,7 +3,7 @@
 import torch
 import torch.distributed as dist
 
-from .ir import Chunk, Route, TransferType
+from .ir import Chunk, Route, Transport
 from .utils import (
     get_slicer_tuples,
     get_slice_from_multi_index,
@@ -48,7 +48,7 @@ def map_to_chunk_ops(
     broadcast_groups = set()
 
     for route in routes:
-        if route.kind == TransferType.BROADCAST:
+        if route.kind == Transport.BROADCAST:
             group_ranks = (route.src.rank,) + tuple(sorted({d.rank for d in route.dsts}))
             broadcast_groups.add(group_ranks)
     for group_ranks in sorted(broadcast_groups):
@@ -58,10 +58,10 @@ def map_to_chunk_ops(
     for route in routes:
         src_rank = route.src.rank
         src_idx = route.src.cell
-        transfer_type = route.kind
+        transport = route.kind
         dst_ranks: tuple[int, ...] = tuple(sorted({d.rank for d in route.dsts}))
+        src_slice_tuples: tuple[slice, ...] = ()
         if src_rank == rank:
-            src_slice_tuples: tuple[slice, ...] = ()
             if source_slicer_tuples is not None and source_num_slicers_extended is not None:
                 src_slice_tuples = get_slice_from_multi_index(
                     src_idx, source_num_slicers_extended, source_slicer_tuples
@@ -70,12 +70,13 @@ def map_to_chunk_ops(
             chunks.append(
                 Chunk(
                     chunk_shape=calculate_chunk_shape(source_num_slicers_extended, source_tensor_shape),
-                    transfer_type=transfer_type,
+                    transport=transport,
                     is_source=True,
+                    is_target=False,
                     src_rank=rank,
                     src_idx=src_idx,
                     dst_ranks=dst_ranks,
-                    slice_tuples=src_slice_tuples,
+                    src_slice=src_slice_tuples,
                     tensor=source_tensor,
                     transfer_dtype=transfer_dtype,
                     source_partial_groups=source_partial_groups,
@@ -84,44 +85,44 @@ def map_to_chunk_ops(
         for dst in route.dsts:
             dst_rank = dst.rank
             dst_idx = dst.cell
-            if dst_rank == rank:
-                if src_rank == rank:
-                    actual_transfer_type = TransferType.SELF_COPY
-                else:
-                    actual_transfer_type = transfer_type
-                dst_slice_tuples: tuple[slice, ...] = ()
-                if target_slicer_tuples is not None and target_num_slicers_extended is not None:
-                    dst_slice_tuples = get_slice_from_multi_index(
-                        dst_idx, target_num_slicers_extended, target_slicer_tuples
+            if dst_rank != rank:
+                continue
+            dst_slice_tuples: tuple[slice, ...] = ()
+            if target_slicer_tuples is not None and target_num_slicers_extended is not None:
+                dst_slice_tuples = get_slice_from_multi_index(
+                    dst_idx, target_num_slicers_extended, target_slicer_tuples
+                )
+            if src_rank == rank:
+                # dst landed on the source rank: read source, write target locally.
+                chunks.append(
+                    Chunk(
+                        chunk_shape=calculate_chunk_shape(target_num_slicers_extended, target_tensor_shape),
+                        transport=Transport.LOCAL,
+                        is_source=True,
+                        is_target=True,
+                        src_rank=src_rank,
+                        src_idx=src_idx,
+                        dst_ranks=dst_ranks,
+                        dst_idx=dst_idx,
+                        src_slice=src_slice_tuples,
+                        dst_slice=dst_slice_tuples,
+                        tensor=target_tensor,
                     )
-                if actual_transfer_type == TransferType.SELF_COPY:
-                    chunks.append(
-                        Chunk(
-                            chunk_shape=calculate_chunk_shape(target_num_slicers_extended, target_tensor_shape),
-                            transfer_type=actual_transfer_type,
-                            is_source=True,
-                            src_rank=src_rank,
-                            src_idx=src_idx,
-                            dst_ranks=dst_ranks,
-                            dst_idx=dst_idx,
-                            slice_tuples=dst_slice_tuples,
-                            src_slice_tuples=src_slice_tuples,
-                            tensor=target_tensor,
-                        )
+                )
+            else:
+                chunks.append(
+                    Chunk(
+                        chunk_shape=calculate_chunk_shape(target_num_slicers_extended, target_tensor_shape),
+                        transport=transport,
+                        is_source=False,
+                        is_target=True,
+                        src_rank=src_rank,
+                        src_idx=src_idx,
+                        dst_ranks=dst_ranks,
+                        dst_idx=dst_idx,
+                        dst_slice=dst_slice_tuples,
+                        tensor=target_tensor,
+                        transfer_dtype=transfer_dtype,
                     )
-                else:
-                    chunks.append(
-                        Chunk(
-                            chunk_shape=calculate_chunk_shape(target_num_slicers_extended, target_tensor_shape),
-                            transfer_type=actual_transfer_type,
-                            is_source=False,
-                            src_rank=src_rank,
-                            src_idx=src_idx,
-                            dst_ranks=dst_ranks,
-                            dst_idx=dst_idx,
-                            slice_tuples=dst_slice_tuples,
-                            tensor=target_tensor,
-                            transfer_dtype=transfer_dtype,
-                        )
-                    )
+                )
     return chunks

--- a/src/etha/comm/get_m2m_map.py
+++ b/src/etha/comm/get_m2m_map.py
@@ -10,7 +10,7 @@ import torch.distributed as dist
 from torch.distributed._tensor import Shard, Replicate, DeviceMesh, distribute_tensor
 from torch.distributed.tensor.placement_types import Partial, Placement
 
-from .ir import Route, Endpoint, TransferType
+from .ir import Route, Endpoint, Transport
 from .utils import enumerate_partial_subgroup_ranks
 
 logger = logging.getLogger(__name__)
@@ -28,11 +28,11 @@ def _dict_to_routes(m2m_map: dict[int, dict[tuple, list[tuple[int, tuple]]]]) ->
         for cell in sorted(cells):
             dsts = tuple(Endpoint(rank=r, cell=c) for r, c in cells[cell])
             if not dsts:
-                kind = TransferType.SHADOW
+                kind = Transport.NONE
             elif len(dsts) > 1:
-                kind = TransferType.BROADCAST
+                kind = Transport.BROADCAST
             else:
-                kind = TransferType.P2P
+                kind = Transport.P2P
             routes.append(Route(src=Endpoint(rank=src_rank, cell=cell), dsts=dsts, kind=kind))
     return routes
 
@@ -65,10 +65,10 @@ def _expand_partial_shadows(
     source_mesh: DeviceMesh,
     source_placements: tuple[Placement, ...],
 ) -> dict[int, dict[tuple, list[tuple[int, tuple]]]]:
-    """Insert SHADOW entries so every Partial sub-group member participates in reduce.
+    """Insert reduce-only entries so every Partial sub-group member participates in reduce.
 
-    Trace selects one primary per cell; the remaining Partial peers need SHADOW
-    entries (empty ``dst_list``) so they reach the chunk-level all-reduce.
+    Trace selects one primary per cell; the remaining Partial peers need
+    reduce-only entries (empty ``dst_list``) so they reach the chunk-level all-reduce.
     Propagation is transitive: a rank's chunk at cell C drives *all* of its
     sub-groups' reduces, so the whole connected component (sub-groups linked
     via shared members) must be present at C.
@@ -130,7 +130,7 @@ def get_m2m_map(
     """Get P2P communication map for tensor redistribution.
 
     Source Partial is supported by substituting Partial→Replicate for the trace,
-    then inserting SHADOW entries for the dropped peers via
+    then inserting reduce-only entries for the dropped peers via
     ``_expand_partial_shadows``. Target Partial is rejected — the decomposition
     of a logical tensor into Partial contributions is not uniquely defined
     across an independent process-group boundary.

--- a/src/etha/comm/ir.py
+++ b/src/etha/comm/ir.py
@@ -7,7 +7,7 @@ import torch
 import msgspec
 import torch.distributed as dist
 
-from .transfer import Transferable, TransferType
+from .transfer import Transport, Transferable
 
 logger = logging.getLogger(__name__)
 
@@ -22,14 +22,14 @@ class Endpoint(msgspec.Struct, frozen=True):
 class Route(msgspec.Struct, frozen=True):
     """One source cell's delivery: ``src`` endpoint to a set of dst endpoints.
 
-    ``kind`` is fixed at construction: empty ``dsts`` -> SHADOW (reduce-only),
-    else BROADCAST (>1) or P2P (1). SELF_COPY is not a route kind; it is refined
-    per-dst at execution when a dst lands on the source rank.
+    ``kind`` is fixed at construction: empty ``dsts`` -> NONE (reduce-only),
+    else BROADCAST (>1) or P2P (1). LOCAL is not a route kind; a dst that lands
+    on the source rank is refined to a local copy when chunks are built.
     """
 
     src: Endpoint
     dsts: tuple[Endpoint, ...]
-    kind: TransferType
+    kind: Transport
 
 
 _REDUCE_OP_MAP = {
@@ -47,14 +47,15 @@ class Chunk(Transferable):
 
     chunk_shape: tuple[int, ...]  # Shape of the data being transferred
     tensor: torch.Tensor | None = None
-    slice_tuples: tuple[slice, ...] = ()  # Slice tuple for tensor indexing (dst for recv/self-copy)
+    src_slice: tuple[slice, ...] = ()  # read here when is_source
+    dst_slice: tuple[slice, ...] = ()  # written here when is_target
     transfer_dtype: torch.dtype | None = None  # Wire dtype (None = use tensor.dtype, set in __post_init__)
     src_idx: tuple  # Multi-dimensional index in source tensor
-    dst_idx: tuple | None = None  # Multi-dimensional index in target tensor (recv/self-copy only)
-    src_slice_tuples: tuple[slice, ...] | None = None  # Source slice (self-copy only)
+    dst_idx: tuple | None = None  # Multi-dimensional index in target tensor (consumers only)
     # NCCL sub-groups + reduce_op for collapsing source Partial to Replicate
     # before send. Routing emits a chunk per (member, cell) so every member
-    # reaches the collective; SHADOW chunks participate without shipping.
+    # reaches the collective; reduce-only (NONE transport) chunks participate
+    # without shipping.
     source_partial_groups: list[tuple[dist.ProcessGroup, str]] | None = field(default=None)
 
     def __post_init__(self) -> None:
@@ -63,30 +64,29 @@ class Chunk(Transferable):
 
     def __repr__(self) -> str:
         """Return a concise representation for debugging."""
+        role = "".join(c for c, on in (("S", self.is_source), ("T", self.is_target)) if on) or "-"
         return (
             f"Chunk("
-            f"type={self.transfer_type.name[:3] if self.transfer_type else '???'}, "
+            f"{self.transport.name[:3]}/{role}, "
             f"src={self.src_rank}→{self.dst_ranks}, "
             f"tensor={self.tensor is not None})"
         )
 
     def prepare(self, contiguous: bool = True) -> None:
-        """Prepare source/target buffer.
+        """Prepare the buffer.
 
-        Source side performs (in order): slice → in-place all-reduce on
-        Partial sub-groups (in source dtype) → cast to ``transfer_dtype``.
-        Reducing before the cast matches DTensor ``Partial → Replicate``
-        semantics; running the all-reduce in the (possibly lower-precision)
-        wire dtype would change numerical results.
+        ``is_source`` reads ``src_slice`` then performs (in order): in-place
+        all-reduce on Partial sub-groups (in source dtype) → cast to
+        ``transfer_dtype``. Reducing before the cast matches DTensor
+        ``Partial → Replicate`` semantics; running the all-reduce in the
+        (possibly lower-precision) wire dtype would change numerical results.
+        A consume-only chunk (recv) instead views ``dst_slice`` so the wire
+        op lands directly in the target.
         """
-        if self.transfer_type == TransferType.SELF_COPY:
-            buffer = self.tensor[self.src_slice_tuples]
-        else:
-            buffer = self.tensor[self.slice_tuples]
+        if self.is_source:
+            buffer = self.tensor[self.src_slice]
             if contiguous:
                 buffer = buffer.contiguous()
-
-        if self.is_source and self.transfer_type != TransferType.SELF_COPY:
             if self.source_partial_groups:
                 # all_reduce is in-place; ensure we own the storage so the
                 # source tensor isn't mutated. Storage-level alias check —
@@ -98,6 +98,10 @@ class Chunk(Transferable):
                     dist.all_reduce(buffer, op=_REDUCE_OP_MAP[op_str], group=group)
             if self.transfer_dtype and self.transfer_dtype != buffer.dtype:
                 buffer = buffer.to(self.transfer_dtype)
+        else:
+            buffer = self.tensor[self.dst_slice]
+            if contiguous:
+                buffer = buffer.contiguous()
 
         self.buffer = buffer
 
@@ -106,22 +110,26 @@ class Chunk(Transferable):
         if self.work is not None:
             self.work.wait()
             self.work = None
-        if self.transfer_type == TransferType.SELF_COPY or not self.is_source:
+        if self.is_target:
             buffer = self.buffer
-            # Target: convert from transfer_dtype to tensor.dtype if different
             if buffer.dtype != self.tensor.dtype:
                 buffer = buffer.to(self.tensor.dtype)
-            self.tensor[self.slice_tuples].copy_(buffer, non_blocking=True)
+            self.tensor[self.dst_slice].copy_(buffer, non_blocking=True)
         self.buffer = None
 
     @property
     def bucket_key(self) -> tuple:
         """Return bucket grouping key.
 
-        ``cell_key`` is added for SHADOW Partial chunks only — they all share
-        ``dst_ranks=()`` and would otherwise bundle across cells, making the
-        bucket's all_reduce sequence per-rank-specific and out of sync with
-        peer ranks whose matching cells live in separate buckets. PRIMARY
+        ``transport`` is in the key so a local (self-copy) chunk never bundles
+        with a co-located broadcast source chunk: they share ``src_rank`` and
+        ``dst_ranks`` but must run different ops and produce buffers of
+        different sizes across the broadcast group.
+
+        ``cell_key`` is added for reduce-only Partial chunks only — they all
+        share ``dst_ranks=()`` and would otherwise bundle across cells, making
+        the bucket's all_reduce sequence per-rank-specific and out of sync with
+        peer ranks whose matching cells live in separate buckets. Shipping
         chunks already differ by ``dst_ranks`` across cells.
         """
         partial_sig: tuple = ()
@@ -130,7 +138,7 @@ class Chunk(Transferable):
             partial_sig = tuple((id(g), op) for g, op in self.source_partial_groups)
             if not self.dst_ranks:
                 cell_key = self.src_idx
-        return (self.src_rank, self.dst_ranks, partial_sig, cell_key)
+        return (self.src_rank, self.dst_ranks, partial_sig, cell_key, self.transport)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -154,26 +162,28 @@ class Bucket(Transferable):
 
     def __repr__(self) -> str:
         """Return a concise representation for debugging."""
-        kind = "src" if self.is_source else "dst"
-        return f"Bucket({kind}, key={self.key} entries_len={len(self.entries)} src_rank={self.src_rank}→dst_ranks={self.dst_ranks})"
+        role = "".join(c for c, on in (("S", self.is_source), ("T", self.is_target)) if on) or "-"
+        return f"Bucket({self.transport.name[:3]}/{role}, key={self.key} entries_len={len(self.entries)} src_rank={self.src_rank}→dst_ranks={self.dst_ranks})"
 
     def prepare(self) -> None:
         """Prepare buffer for communication.
 
         Source-side Partial reduce and dtype cast both live inside
         ``Chunk.prepare``; this method only assembles entries into the
-        bucket buffer.
+        bucket buffer. A producing chunk's data is copied into the bucket;
+        the per-chunk buffer is kept only when the chunk also ``is_target``
+        (self-copy), so ``finalize`` can write it to the target. A consume-only
+        recv instead points its buffer at the bucket slice to land directly.
         """
         if len(self.entries) == 1:
             chunk = self.entries[0].chunk
             chunk.prepare()
             self.buffer = chunk.buffer.view(torch.uint8)
-            if self.is_source:
+            if not chunk.is_target:
                 chunk.buffer = None
             return
 
         self.buffer = torch.empty(self.total_bytes, dtype=torch.uint8, device=self.device)
-        needs_copy = self.is_source or self.transfer_type == TransferType.SELF_COPY
 
         for entry in self.entries:
             chunk = entry.chunk
@@ -181,14 +191,14 @@ class Bucket(Transferable):
             numel = entry.nbytes // dtype.itemsize
             buffer_slice = self.buffer.narrow(0, entry.offset, entry.nbytes).view(dtype)[:numel].view(chunk.chunk_shape)
 
-            if needs_copy:
+            if self.is_source:
                 chunk.prepare(contiguous=False)
                 buffer_slice.copy_(chunk.buffer, non_blocking=True)
-                chunk.buffer = None
+                chunk.buffer = buffer_slice if chunk.is_target else None
             else:
                 chunk.buffer = buffer_slice
 
-        if needs_copy:
+        if self.is_source:
             event = torch.cuda.Event()
             event.record()
             self.buffer_ready_event = event
@@ -227,7 +237,7 @@ class Bucket(Transferable):
             self.work.wait()
             self.work = None
 
-        if not self.is_source:
+        if self.is_target:
             for entry in self.entries:
                 entry.chunk.finalize()
 

--- a/src/etha/comm/transfer.py
+++ b/src/etha/comm/transfer.py
@@ -9,16 +9,13 @@ import torch.distributed as dist
 from .utils import get_or_create_process_group
 
 
-class TransferType(Enum):
-    """Transfer operation types."""
+class Transport(Enum):
+    """How a chunk's bytes cross ranks (orthogonal to its produce/consume role)."""
 
-    SELF_COPY = "self_copy"  # Local copy within same rank
     P2P = "p2p"
     BROADCAST = "broadcast"
-    # Reduce-only chunks: a source rank participates in the source-Partial
-    # all-reduce (collective; every sub-group member must call) but isn't the
-    # ship-primary for this logical cell. After reduce, the buffer is discarded.
-    SHADOW = "shadow"
+    LOCAL = "local"  # same-rank copy, no wire op
+    NONE = "none"  # reduce-only ("shadow"): participates in a collective but ships nothing
 
 
 def _execute_p2p(
@@ -47,10 +44,17 @@ def _execute_broadcast(
 
 @dataclass(slots=True, kw_only=True)
 class Transferable:
-    """Base class for transferable objects (chunks and buckets)."""
+    """Base class for transferable objects (chunks and buckets).
 
-    transfer_type: TransferType
+    Role and transport are orthogonal:
+    - ``is_source``: reads a local tensor into ``buffer`` (source side / self-copy).
+    - ``is_target``: writes ``buffer`` back into a local target tensor (recv / self-copy).
+    - ``transport``: how bytes cross ranks. ``LOCAL``/``NONE`` never hit the wire.
+    """
+
+    transport: Transport
     is_source: bool
+    is_target: bool
     src_rank: int
     dst_ranks: tuple[int, ...]
     buffer: torch.Tensor | None = None
@@ -60,14 +64,12 @@ class Transferable:
         """Execute transfer operation.
 
         Returns:
-            Work handle for async operations, None for SELF_COPY / SHADOW.
+            Work handle for async transports, None for LOCAL / NONE.
         """
-        match self.transfer_type:
-            case TransferType.SELF_COPY:
+        match self.transport:
+            case Transport.LOCAL | Transport.NONE:
                 return None
-            case TransferType.SHADOW:
-                return None
-            case TransferType.P2P:
+            case Transport.P2P:
                 return _execute_p2p(self.buffer, self.is_source, self.src_rank, self.dst_ranks[0])
-            case TransferType.BROADCAST:
+            case Transport.BROADCAST:
                 return _execute_broadcast(self.buffer, self.src_rank, self.dst_ranks)

--- a/tests/test_self_copy_bucket.py
+++ b/tests/test_self_copy_bucket.py
@@ -1,0 +1,65 @@
+"""A local (self-copy) chunk must write its target through both paths.
+
+A local chunk both ``is_source`` (reads a source slice) and ``is_target`` (writes
+a target slice). ``Bucket.finalize`` writes when ``is_target``; both the single
+and bundled bucket paths must land the copy in the target tensor — same as the
+direct chunk path.
+"""
+
+import os
+import socket
+
+import torch
+import pytest
+import torch.distributed as dist
+
+from etha.comm import chunk_comm, bucket_comm, chunk_to_bucket_ops
+from etha.comm.ir import Chunk, Transport
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def single_rank_pg():
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(_free_port())
+    dist.init_process_group(backend="gloo", rank=0, world_size=1)
+    yield
+    dist.destroy_process_group()
+
+
+def _make_self_copy_chunk(tensor: torch.Tensor) -> Chunk:
+    """Mirror map_to_chunk_ops' local construction.
+
+    Reads the src slice, writes the dst slice, single tensor, is_source + is_target.
+    """
+    return Chunk(
+        chunk_shape=(4,),
+        transport=Transport.LOCAL,
+        is_source=True,
+        is_target=True,
+        src_rank=0,
+        src_idx=(0,),
+        dst_ranks=(0,),
+        dst_idx=(1,),
+        src_slice=(slice(0, 4),),  # src
+        dst_slice=(slice(4, 8),),  # dst
+        tensor=tensor,
+    )
+
+
+def test_self_copy_chunk_path(single_rank_pg):
+    t = torch.tensor([1.0, 2, 3, 4, 0, 0, 0, 0])
+    chunk_comm([_make_self_copy_chunk(t)])
+    assert torch.equal(t[4:8], torch.tensor([1.0, 2, 3, 4]))
+
+
+def test_self_copy_bucket_path(single_rank_pg):
+    t = torch.tensor([1.0, 2, 3, 4, 0, 0, 0, 0])
+    buckets = chunk_to_bucket_ops([_make_self_copy_chunk(t)], bucket_size=256 * 1024)
+    bucket_comm(buckets)
+    assert torch.equal(t[4:8], torch.tensor([1.0, 2, 3, 4]))


### PR DESCRIPTION
## What did you do

Follow-up to the typed-`Route` refactor (#99 / #101). The chunk/bucket transfer IR conflated two orthogonal axes into one `TransferType` enum (`P2P`/`BROADCAST`/`SELF_COPY`/`SHADOW`) plus an overloaded `is_source` bool:
- `is_source` meant "ships data out" for `prepare`/`execute`,
- but `not is_source` was reused as "writes a target" in `finalize`.

A self-copy chunk does both, so `Bucket.finalize`'s `if not is_source` **dropped the local write**. Latent in production (disjoint meshes → self-copy never fires), but real — see `tests/test_self_copy_bucket.py`.

Split into three orthogonal fields:
- **`transport: Transport`** — how bytes cross ranks: `P2P` / `BROADCAST` / `LOCAL` (same-rank copy) / `NONE` (reduce-only, was `SHADOW`).
- **`is_source`** — reads a local tensor into the buffer.
- **`is_target`** — writes the buffer back into a local target tensor.

`SELF_COPY` → `LOCAL ∧ is_source ∧ is_target`; `SHADOW` → `NONE ∧ is_source ∧ ¬is_target`. The two degenerate enum values disappear. `prepare` keys off `is_source`, `finalize` off `is_target` — one predicate shared by `Chunk` and `Bucket`, so the bucket self-copy drop is **fixed by construction**, not patched. Slice fields renamed `src_slice`/`dst_slice` to pair with `src_idx`/`dst_idx`.

Also: `bucket_key` now includes `transport`, so a local (self-copy) chunk no longer bundles with a co-located broadcast source chunk — they share `src_rank`/`dst_ranks` but need different ops and produce broadcast buffers of **different sizes** across the group (a second latent bug fixed here).

No production behavior change on disjoint meshes; the two latent bugs above are now correct.

## New test cases

`tests/test_self_copy_bucket.py` — a single-rank gloo probe that runs a local (self-copy) chunk through **both** execution paths (direct chunk + bucket) and asserts the copy lands in the target. The bucket path failed before this change.

## Test results

All three verification layers (per `CLAUDE.md`):

| Layer | Result |
|---|---|
| CPU suite (`test_communication_*`, `test_partial_chunk_reduce`) | **55/55** |
| Transfer benchmark — 2-node × 8-GPU NCCL, all 3 configs | **✅** 24 charts; `Transport.P2P` / `BROADCAST` / `NONE` routes live; source-Partial reduce exercised |
| vLLM weight-sync (8 GPUs, end-to-end) | **✅** 3/3 sync rounds, weights propagated (v1→v2) |

## Other comments

Deferred follow-ups, tracked separately:
- #103 — small cleanups (`execute()` owning `self.work`, `Chunk.dst_idx` dead field, overlapping-mesh self-copy correctness).
- #104 — structural simplification: make `Bucket` the sole transfer unit, demote `Chunk` to a data descriptor, collapse the two execution paths into one (benchmark shows the chunk path is also ~2× slower).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for self-copy operations in both chunk and bucketized execution paths.

* **Refactor**
  * Restructured communication routing logic and internal chunk/bucket handling for improved consistency in distributed tensor operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cmriat/Etha/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->