### PR TITLE
refactor(tensor_bus): PairState/BatchState are dataclasses, not Structs

### DIFF
--- a/src/etha/comm/get_chunks.py
+++ b/src/etha/comm/get_chunks.py
@@ -3,12 +3,10 @@
 import torch
 import torch.distributed as dist
 
+from etha.pg_utils import get_or_create_process_group
+
 from .ir import Chunk, M2MMap, Transport
-from .utils import (
-    get_slicer_tuples,
-    get_slice_from_multi_index,
-    get_or_create_process_group,
-)
+from .utils import get_slicer_tuples, get_slice_from_multi_index
 
 
 def calculate_chunk_shape(

--- a/src/etha/comm/transfer.py
+++ b/src/etha/comm/transfer.py
@@ -5,7 +5,7 @@ from enum import Enum
 import torch
 import torch.distributed as dist
 
-from .utils import get_or_create_process_group
+from etha.pg_utils import get_or_create_process_group
 
 
 class Transport(Enum):

--- a/src/etha/comm/utils.py
+++ b/src/etha/comm/utils.py
@@ -7,11 +7,7 @@ import itertools
 
 import torch
 
-# Re-export for backward compatibility
-from etha.pg_utils import get_or_create_process_group
-
 __all__ = [
-    "get_or_create_process_group",
     "get_slicer_tuples",
     "get_slice_from_multi_index",
     "enumerate_partial_subgroup_ranks",

--- a/src/etha/tensor_bus/batch_state.py
+++ b/src/etha/tensor_bus/batch_state.py
@@ -4,18 +4,20 @@ A batch represents one call to register_tensors(). Multiple batches can exist
 for the same pair, each with independent tensors and handlers.
 """
 
+from dataclasses import field, dataclass
+
 import torch
-import msgspec
 import torch.distributed as dist
 
 from etha.comm.ir import Bucket
 
 
-class BatchState(msgspec.Struct):
-    """State for a single batch of registered tensors.
+@dataclass(kw_only=True)
+class BatchState:
+    """Runtime state for a single batch of registered tensors, held on the Agent.
 
-    A batch is created for each register_tensors() call and contains all
-    tensor data and execution plans for that specific registration.
+    Created per register_tensors() call. Holds live tensors, process-group
+    handles, and execution plans (buckets with CUDA work) — in-memory only.
 
     Key design: buckets are FLATTENED across all pairs in the batch, allowing
     single-pass execution via bucket_comm().
@@ -30,8 +32,8 @@ class BatchState(msgspec.Struct):
     batch_group: dist.ProcessGroup | None = None  # all ranks in batch (local + remote across all pairs)
 
     # Data layer: Per-pair organization (for fallback and debugging)
-    pair_tensors: dict[str, list[torch.Tensor]] = msgspec.field(default_factory=dict)
-    pair_target_dtypes: dict[str, list[torch.dtype]] = msgspec.field(default_factory=dict)
+    pair_tensors: dict[str, list[torch.Tensor]] = field(default_factory=dict)
+    pair_target_dtypes: dict[str, list[torch.dtype]] = field(default_factory=dict)
 
     # Execution layer: FLATTENED across all pairs for efficient execution
     send_buckets: list[Bucket] | None = None

--- a/src/etha/tensor_bus/pair_state.py
+++ b/src/etha/tensor_bus/pair_state.py
@@ -1,17 +1,19 @@
 """State."""
 
-import msgspec
+from dataclasses import dataclass
+
 import torch.distributed as dist
 
 from etha.comm.ir import M2MMap
 
 
-class PairState(msgspec.Struct):
-    """State of a registered Pair.
+@dataclass(kw_only=True)
+class PairState:
+    """Runtime state of a registered Pair, held in-memory on the Agent.
 
-    PairState is created once per pair via register_pair() and represents
-    the communication topology. It contains NO tensor data or execution state.
-    All tensor data and execution plans are now stored in BatchState.
+    Created once per pair via register_pair(). Holds live process-group handles
+    and the shape-independent M2M topology; never crosses a process boundary
+    (the Agent only exposes scalar signals to the Client over LMDB).
     """
 
     pair_name: str


### PR DESCRIPTION
## What did you do

Follow-up to #106. `PairState` and `BatchState` subclassed `msgspec.Struct`, but both hold live `ProcessGroup` handles, `torch.Tensor`s and `Bucket`s carrying CUDA work. They never cross a process boundary and can **never** be `msgspec`-encoded — the `Struct` base falsely signalled serializability.

Across the codebase, the only genuine serialization boundary is `Message` (the Host↔Agent command wire format, `command_queue.py`). Query/status flows transmit only scalars (`"matched"`, `bool`) the Agent projects out of its in-memory state — never the state objects themselves. The pure-data comm IR (`Endpoint`/`Route`/`M2MMap`) is genuinely serializable and stays `msgspec.Struct`.

This PR:
- converts the two runtime-state holders to plain `@dataclass(kw_only=True)` and fixes their docstrings (`kw_only` guards the many no-default fields against positional mistakes; all construction sites already pass kwargs; no behavior change). `slots` deliberately omitted — unlike the hot-path `Chunk`/`Bucket`, these are a handful of long-lived instances with no memory payoff.
- drops the `get_or_create_process_group` re-export shim from `comm.utils`; importers now pull it directly from `etha.pg_utils`.

## New test cases

None — pure type/import refactor, no new feature or bug. Covered by the existing 3-layer verification for no behavioral regression.

## Test results

- CPU unit tests: ✅ 55 passed
- vLLM weight-sync end-to-end: ✅ 3/3 rounds, no agent errors
- Transfer benchmark (GPU/NCCL): ✅ bucket 319–327 GB/s (baseline ~319, no regression)

## Other comments

The `msgspec.Struct` base is now reserved for things that actually go on the wire.