### PR TITLE
perf(comm): coalesce non-Partial chunks by default; Partial stays per-chunk

### DIFF
--- a/bench/BUCKET_TUNING.md
+++ b/bench/BUCKET_TUNING.md
@@ -1,0 +1,223 @@
+# Bucket tuning: make coalesced transfer never lose to per-chunk
+
+Goal: a single coalescing policy where the **bucket** (coalesced) method is
+**always ≥** the **chunk** method (`bucket_size=1`, one wire op per chunk) across
+every mesh / shape / placement case in `transfer_benchmark.py`.
+
+Terminology in the benchmark output:
+- **chunk method** = `chunk_to_bucket_ops(chunks, bucket_size=1)` — every chunk is
+  its own single-entry bucket. `prepare` aliases the source slice (zero-copy when
+  contiguous); many small wire ops; no gather/scatter.
+- **bucket method** = `chunk_to_bucket_ops(chunks, bucket_size=BUCKET_SIZE_BYTES)`
+  — same-route chunks coalesced into one buffer + one wire op. Costs N gather
+  `copy_` (send) + N scatter `copy_` (recv) but issues far fewer wire ops.
+
+---
+
+## M1 — investigate & localize (DONE)
+
+### Mechanism (code paths)
+- `Bucket.prepare` (ir.py): single-entry → `chunk.buffer.view(uint8)` (zero-copy
+  alias when the slice is contiguous). Multi-entry → allocate `total_bytes`, then a
+  **python loop of N `copy_`** gathering each chunk into the buffer; recv side points
+  each chunk's buffer at a bucket slice and `finalize` scatters back with N `copy_`.
+- `bucket_comm` (comm_methods.py): per-channel pipeline, `max_in_flight=2`. Buffer
+  assembly (`prepare`) is meant to overlap in-flight collectives. All on the default
+  stream; NCCL runs on its own stream, gated by `buffer_ready_event`.
+- `chunk_to_bucket_ops` (get_buckets.py): **a chunk ≥ `bucket_size` becomes its own
+  bucket**; smaller chunks accumulate until they reach `bucket_size`.
+
+### Data (baseline run, 16 GPUs, 2 nodes, BUCKET_SIZE_BYTES = 256MB)
+Parsed from the full benchmark sweep (8 meshes × 9 shapes × 3 placement configs =
+216 cases). Pattern by tensor size:
+- **≤1024² (≤100MB batch)**: bucket wins big (2–3×). Many tiny chunks → wire-op
+  launch count dominates → coalescing is a clear win.
+- **≥8192² (≥6.4GB batch)**: tie (~1.00). Bandwidth-saturated; copy overlaps wire.
+- **2048²–4096² (400MB–1.6GB) on certain meshes**: **chunk wins by 5–20%**
+  (20/216 cases; 15 of them in `partial_dp`, which adds an all-reduce in `prepare`).
+
+Worst chunk-wins cases (chunk / bucket):
+```
+partial_dp (2,2,2,1)->(1,1,4,2) 4096²  chunk=242 bucket=203  1.20x
+partial_dp (2,4,1,1)->(1,2,4,1) 4096²  chunk=177 bucket=149  1.19x
+partial_dp (4,2,1,1)->(1,1,2,4) 4096²  chunk=242 bucket=204  1.19x
+partial_dp (2,2,2,1)->(1,1,4,2) 8192²  chunk=298 bucket=255  1.17x
+partial_dp (8,1,1,1)->(1,2,2,2) 2048²  chunk=259 bucket=232  1.12x
+```
+
+### Root-cause hypothesis
+`BUCKET_SIZE_BYTES = 256MB` is far larger than any single chunk at these shapes, so
+**all** chunks of a mid-size tensor accumulate into very few huge buckets. Two
+compounding losses:
+1. Hundreds of gather/scatter `copy_` serialized on the critical path.
+2. Too few buckets per channel → `max_in_flight=2` has nothing to overlap, so the
+   copies are fully exposed instead of hidden behind wire.
+
+Per-chunk (`bucket_size=1`) avoids both: zero gather/scatter, and many buckets to
+pipeline.
+
+The fix lever already exists: `chunk_to_bucket_ops` sends any chunk ≥ `bucket_size`
+as its own (zero-copy) bucket. A **moderate** `bucket_size` should let large chunks
+take the chunk-method path (no loss) while still coalescing the small chunks (the
+win) — and keep enough buckets for pipeline overlap.
+
+---
+
+## M2 — sweep bucket_size (IN PROGRESS)
+`benchmark_single_shape` now sweeps `BUCKET_SIZE_SWEEP = {1, 2MB, 8MB, 32MB, 256MB}`
+in one run (1 = chunk method). Each value reuses the same chunk list; the result
+dict carries `sweep_throughput_gb_s`. (Removed the now-unused per-method profiling
+blocks; profiling args kept but unwired, marked noqa.)
+
+Success criterion: one single value where bucket ≥ chunk (within ~2% noise) for all
+216 cases, ideally still winning big on the small shapes.
+
+### Smoke (single node, 8 GPU, NVLink, 1 case: partial_dp 2048², 2 tensors)
+```
+chunk=37.46  2MB=41.59  8MB=33.28  32MB=33.30  256MB=34.60   (GB/s)
+```
+2MB already beats both chunk and 256MB; larger sizes over-coalesce. Sweet spot
+looks small (~2MB). NVLink single-node ≠ the cross-node chunk-wins regime, so this
+only confirms the sweep runs and the direction; full 16-GPU sweep submitted
+(job `slurm-profile-slurm-42ndm`).
+
+## M2 RESULT — no single bucket_size wins (DONE)
+Full 16-GPU sweep, 215 cases. Times each fixed value LOSES to chunk (>2%):
+```
+2MB: 21   8MB: 5   32MB: 6   256MB: 17
+```
+Best-value distribution (which value wins each case):
+```
+32MB: 67   256MB: 55   8MB: 45   chunk: 29   2MB: 19
+```
+8MB is the best single value (loses 5/215, 4 of them ≤1.11x) but is NOT "always
+fastest". The optimum is genuinely case-dependent along **two orthogonal axes**:
+
+1. **Size axis** — optimum bucket_size grows with tensor size. Same mesh
+   `(1,1,4,2)->(4,2,1,1)`: 512²→8MB, 1024²→32MB, 2048²+→256MB. Bigger chunks need
+   bigger buckets to coalesce; large tensors are bandwidth-saturated so the gather
+   copy hides. A fixed value is always wrong for some size.
+2. **Partial axis (the killer)** — same mesh `(1,2,4,1)->(8,1,1,1)` 1024²:
+   no_partial → 32MB=382 (coalesce wins big); partial_dp → chunk=238 best, all
+   coalescing loses. The only difference is the Partial all_reduce. `Bucket.prepare`
+   runs **N serial all_reduce, one per chunk**, on the critical path; chunk method
+   overlaps each all_reduce with its own wire. All chunks in a bucket share the same
+   partial group (it's in `bucket_key`), so the N all_reduce are redundant serial
+   collectives on the same comm.
+
+## M3 — make coalescing not lose (IN PROGRESS)
+Two independent fixes, matching the two axes:
+
+A. **Batch the partial all_reduce** (fixes axis 2). Since a bucket's chunks share
+   one partial group, gather first, then do a SINGLE all_reduce over the whole
+   bucket buffer instead of N per-chunk reduces. Should remove the partial_dp
+   penalty outright. Targeted, low-risk; the bucket_key guarantee makes it safe.
+
+B. **Adaptive bucket_size = f(per-rank bytes)** (fixes axis 1). Pick the threshold
+   so each channel splits into enough buckets to keep the pipeline full (overlap)
+   while still coalescing tiny chunks. Computed in the agent/caller from the batch's
+   byte volume — transparent to the user ("no-brainer").
+
+Order: do A first (it's the larger, cleaner win and explains most partial losses),
+re-sweep, then size B to close any residual size-axis gap.
+
+### M3-A implemented + smoke-verified
+`Bucket.prepare` now gathers the whole bucket first, then runs ONE all_reduce over
+the buffer (guarded by uniform dtype, no wire downcast). Smoke (single node, 8 GPU,
+2048² partial_dp), before → after:
+```
+            chunk   2MB    8MB    32MB   256MB
+before      37.5    41.6   33.3   33.3   34.6
+after       38.7    41.6   43.4   46.5   41.7
+```
+Coalescing flipped from losing (33<37) to winning (43–47>39); correctness check
+passed. Confirms the partial penalty was the serial per-chunk all_reduce.
+
+### M3-A 16-GPU re-sweep, take 1 (`hs227`) — partial, but encouraging
+Hit the 1h `#SBATCH --time` wall (5-point sweep too slow); only 172/215 cases ran
+before SLURM cut it (succeeded, not a hang). On the cases that DID run, 8MB loses to
+chunk in **0** cases (was 5), 256MB 6 (was 17). The previously-worst
+`(8,1,1,1)->(1,2,2,2)` mid shapes flipped (2048²: 8MB=252 > chunk=228, was 256MB=225
+lost). BUT the single worst mesh `(2,2,2,1)->(1,1,4,2)` only reached 512² before the
+cut — its 4096²/8192² (the 1.18x losers) were NOT measured. So 8MB=0-losses is on
+incomplete data; not conclusive yet.
+
+### take 2 (`ckmtc`) — M3-A DEADLOCKED, reverted
+Failed: NCCL ALLREDUCE timeout with **mismatched sizes across ranks** in the same
+collective (Rank 3 NumelIn=262144 vs Rank 1 NumelIn=2097152, 8×).
+
+Root cause of the M3-A bug: in a Partial reduce group, reduce-only chunks (dst=(),
+distinct `cell_key`) each become their own single-entry bucket → per-cell
+all_reduce; shipping chunks (dst≠()) coalesce → one batched all_reduce. So a
+shipping rank issues ONE big all_reduce (8 cells = 2M) while a reduce-only rank
+issues MANY small ones (1 cell = 256K) on the same group → size/count mismatch →
+deadlock. Per-chunk (bucket_size=1) keeps both at per-cell granularity, aligned.
+**Batched all_reduce is fundamentally unsafe here; reverted `Bucket.prepare`.**
+
+## M3-B — don't coalesce Partial — FAILED (correctness), reverted
+Tried: a chunk with `source_partial_groups` always gets its own bucket. Smoke:
+no_partial / replicate_dp pass, partial_dp mismatches (Max diff ~6.9 = wrong, not
+numerical). Isolated: `[1]`-only passes (single-entry Partial is correct);
+`[32MB]`-only fails (so it's the coalesced path × Partial, not sweep-state leak).
+
+Root cause: send and recv are bucketized **separately** (`agent.py` builds
+`send_buckets` / `recv_buckets` independently). `source_partial_groups` lives only on
+the SOURCE chunk, so "don't coalesce Partial" fired on the sender (N single-entry
+sends) but NOT on the matching receiver (one coalesced recv) → P2P send/recv buffer
+sizes mismatch → data lands at wrong offsets. **Any bucketing rule must be symmetric
+across the send/recv pair; a source-only signal breaks it.** Reverted.
+
+## The Partial dead end — all three tried
+- batched all_reduce → deadlock (reduce-only per-cell vs shipping batched misalign)
+- don't-coalesce-Partial → P2P send/recv asymmetry (signal only on sender)
+- original coalescing → correct, but serial per-chunk all_reduce is slow on mid sizes
+
+Coalescing helps non-Partial cleanly; Partial is boxed in by two invariants:
+(1) the per-cell all_reduce must stay aligned across the reduce group, and
+(2) send/recv bucketing must be symmetric across the P2P pair. A source-only tweak
+violates one or both.
+
+A correct "don't coalesce Partial" needs the signal on BOTH ends: tag the matching
+target recv chunk too (derive from the route's Partial source in `m2m_to_chunks`,
+carry a `no_coalesce` flag on Chunk). That's a design change beyond tuning — needs
+sign-off. With it: Partial → bucket == chunk (no loss), non-Partial → 8MB wins,
+which satisfies "bucket ≥ chunk everywhere".
+
+## M3-C — symmetric `no_coalesce` flag (the fix for M3-B)
+Chosen direction. Put the don't-coalesce signal where BOTH ends see it: keyed off
+`M2MMap.source_partial_reductions` (same map on source and target ranks).
+- `Chunk.no_coalesce: bool` — new field.
+- `m2m_to_chunks`: `no_coalesce = bool(m2m.source_partial_reductions)`, set on every
+  chunk it builds (send and recv), so the two ends bucketize identically.
+- `chunk_to_bucket_ops`: a `no_coalesce` chunk stays single-entry.
+
+Result: Partial transfers → all chunks single-entry on both ends (per-cell
+all_reduce, aligned; P2P send/recv symmetric) = chunk method = Partial's optimum.
+Non-Partial → coalesce by `bucket_size`.
+
+Smoke (single node, partial_dp mesh WITH a real reduce — `Transport.NONE` chunks
+present): **passes** where M3-B mismatched. Confirms the symmetric flag fixes the
+send/recv asymmetry.
+
+### M3-C 16-GPU sweep (`kgj5c`) — PASS
+Completed cleanly, all 216 blocks, **no deadlock, no mismatch**. 8MB loses to chunk
+in 14/215 cases — **all 14 are partial_dp, all ≤1.11x**, none in no_partial/
+replicate_dp. Since Partial chunks are `no_coalesce`, the 8MB and chunk runs build
+the *same* single-entry buckets for those cases, so the gap is pure measurement
+noise (concentrated on small tensors). Net: **non-Partial 8MB ≥ chunk everywhere;
+Partial == chunk (its optimum). 8MB + no_coalesce is the no-brainer-fastest policy.**
+
+## M4 — ship (IN PROGRESS)
+- `agent.py`: default `coalesce_bytes` 1 → `DEFAULT_COALESCE_BYTES` (8MB). Partial
+  self-excludes via `no_coalesce`.
+- Validated: CPU unit tests ✅ 55 passed; vLLM weight-sync ✅ 3/3 rounds, no agent
+  errors (production Partial MoE on the new 8MB default).
+- Shipped: commit `fe94326`, PR #109.
+
+## Outcome
+`8MB + no_coalesce` is the no-brainer-fastest policy: non-Partial coalesces (wins up
+to 3x on small tensors, ties on large), Partial self-excludes and runs its optimal
+per-chunk path. bucket ≥ chunk across all 215 sweep cases, no deadlock, no mismatch.
+The Partial path is structurally protected by two invariants we learned the hard
+way: per-cell all_reduce alignment across the reduce group, and symmetric send/recv
+bucketing.

--- a/bench/transfer_benchmark.py
+++ b/bench/transfer_benchmark.py
@@ -12,8 +12,6 @@ import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 import torch.distributed as dist
-from upath import UPath
-from utils import ProfilingSpec, dump_memory_snapshot, maybe_enable_profiling
 from torch.distributed._tensor import Shard, Replicate, DeviceMesh, distribute_tensor
 from torch.distributed.tensor.placement_types import Partial, _StridedShard
 
@@ -31,6 +29,9 @@ from etha.comm.utils import enumerate_partial_subgroup_ranks
 RDMA_SEND_BANDWIDTH_GB_S = 50.0
 NVLINK_Single_BANDWIDTH_GB_S = 450.0
 BUCKET_SIZE_BYTES = 256 * 1024 * 1024
+# bucket_size sweep (bytes). 1 = per-chunk (no coalescing) = the "chunk" method.
+# Trimmed to the contenders after M2: 2MB/256MB were never the answer.
+BUCKET_SIZE_SWEEP = [1, 8 * 1024 * 1024, 32 * 1024 * 1024]
 
 
 def calculate_transfer_bytes(
@@ -118,7 +119,6 @@ def benchmark_single_shape(
     num_tensors: int,  # Logical batch size (origin_tensors holds only index 0 to save memory)
     shape: tuple,
     chunks: list,  # All chunks from all tensors (extended)
-    buckets: list,
     current_source_mesh: DeviceMesh,
     current_target_mesh: DeviceMesh,
     source_specs: list,
@@ -130,8 +130,9 @@ def benchmark_single_shape(
     warmup_iter: int,
     profile_iter: int,
     gpus_per_node: int,
-    profiling_config: dict | None = None,
-    mesh_info: str = "",
+    bucket_sizes: list[int],
+    profiling_config: dict | None = None,  # noqa: ARG001
+    mesh_info: str = "",  # noqa: ARG001
     has_partial: bool = False,
 ):
     """Benchmark M2M vs Gather-Broadcast for a batch of tensors.
@@ -149,118 +150,30 @@ def benchmark_single_shape(
     # Calculate total size of all tensors in batch (per-tensor size × num_tensors).
     total_tensor_size_bytes = origin_tensors[0].nelement() * origin_tensors[0].element_size() * num_tensors
 
-    # Check if we need to profile this shape
-    should_profile = profiling_config is not None and shape in profiling_config["profile_shapes"]
-
-    # M2M method = single-entry buckets (no coalescing); built once, reused.
-    m2m_buckets = chunk_to_bucket_ops(chunks=chunks, bucket_size=1)
-
-    # M2M method warmup
-    dist.barrier()
-    for _ in range(warmup_iter):
-        bucket_comm(buckets=m2m_buckets)
-    if device == "cuda":
+    def _time_buckets(buckets) -> float:
+        dist.barrier()
+        for _ in range(warmup_iter):
+            bucket_comm(buckets=buckets)
+        if device == "cuda":
+            torch.cuda.synchronize()
+        dist.barrier()
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        for _ in range(profile_iter):
+            bucket_comm(buckets=buckets)
+        end_event.record()
         torch.cuda.synchronize()
-    dist.barrier()
+        return start_event.elapsed_time(end_event) / 1000.0 / profile_iter  # ms -> s
 
-    # M2M method with profiling if enabled
-    if should_profile:
-        m2m_profiling_spec = ProfilingSpec(
-            enable_profiling=True,
-            dump_folder=UPath(profiling_config["dump_folder"]),
-            save_traces_folder=UPath(f"traces/{mesh_info}/shape_{shape[0]}/rank_{rank}/m2m"),
-            profile_freq=profiling_config["profile_freq"],
-            warmup_steps=profiling_config["warmup_steps"],
-            active_steps=profiling_config["active_steps"],
-            enable_memory_snapshot=profiling_config["enable_memory_snapshot"],
-        )
+    # Sweep bucket_size. bucket_size=1 is the per-chunk (no coalescing) method.
+    sweep_time: dict[int, float] = {}
+    for bs in bucket_sizes:
+        sweep_buckets = chunk_to_bucket_ops(chunks=chunks, bucket_size=bs)
+        sweep_time[bs] = _time_buckets(sweep_buckets)
 
-        with maybe_enable_profiling(m2m_profiling_spec, global_step=0) as profiler:
-            if profiler is not None:
-                # Profiled iterations
-                for step in range(m2m_profiling_spec.profile_freq):
-                    if device == "cuda":
-                        torch.cuda.synchronize()
-                    dist.barrier()
-                    profiler.step()
-                    for _ in range(10):
-                        bucket_comm(buckets=m2m_buckets)
-
-                    # Memory snapshot if requested
-                    if m2m_profiling_spec.enable_memory_snapshot and step == m2m_profiling_spec.warmup_steps + 1:
-                        snapshot_dir = f"{m2m_profiling_spec.dump_folder}/memory_snapshots/{mesh_info}/shape_{shape[0]}/rank_{rank}"
-                        dump_memory_snapshot(snapshot_dir, step, rank)
-            else:
-                pass
-
-    # Time measurement with CUDA events
-    if device == "cuda":
-        torch.cuda.synchronize()
-    dist.barrier()
-
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
-
-    start_event.record()
-    for _ in range(profile_iter):
-        bucket_comm(buckets=m2m_buckets)
-    end_event.record()
-
-    torch.cuda.synchronize()
-    m2m_time = start_event.elapsed_time(end_event) / 1000.0 / profile_iter  # ms -> s
-
-    dist.barrier()
-    for _ in range(warmup_iter):
-        bucket_comm(buckets=buckets)
-    if device == "cuda":
-        torch.cuda.synchronize()
-    dist.barrier()
-
-    if should_profile:
-        bucket_profiling_spec = ProfilingSpec(
-            enable_profiling=True,
-            dump_folder=UPath(profiling_config["dump_folder"]),
-            save_traces_folder=UPath(f"traces/{mesh_info}/shape_{shape[0]}/rank_{rank}/bucket_comm"),
-            profile_freq=profiling_config["profile_freq"],
-            warmup_steps=profiling_config["warmup_steps"],
-            active_steps=profiling_config["active_steps"],
-            enable_memory_snapshot=profiling_config["enable_memory_snapshot"],
-        )
-
-        with maybe_enable_profiling(bucket_profiling_spec, global_step=0) as profiler:
-            if profiler is not None:
-                for step in range(bucket_profiling_spec.profile_freq):
-                    if device == "cuda":
-                        torch.cuda.synchronize()
-                    dist.barrier()
-                    profiler.step()
-                    for _ in range(10):
-                        bucket_comm(buckets=buckets)
-                    if bucket_profiling_spec.enable_memory_snapshot and step == bucket_profiling_spec.warmup_steps + 1:
-                        snapshot_dir = f"{bucket_profiling_spec.dump_folder}/memory_snapshots/{mesh_info}/shape_{shape[0]}/rank_{rank}"
-                        dump_memory_snapshot(snapshot_dir, step + 2000, rank)
-            else:
-                pass
-
-    # Time measurement with CUDA events
-    if device == "cuda":
-        torch.cuda.synchronize()
-    dist.barrier()
-
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
-
-    start_event.record()
-    for _ in range(profile_iter):
-        bucket_comm(buckets=buckets)
-    end_event.record()
-
-    torch.cuda.synchronize()
-    bucket_time = start_event.elapsed_time(end_event) / 1000.0 / profile_iter  # ms -> s
-
-    # Gather-Broadcast method warmup (only test first tensor as reference).
-    # For Partial source: user manually redistributes to Replicate first (inside
-    # the timed loop so the reduce cost is counted), then calls gather_broadcast.
+    # Gather-Broadcast baseline (reference). For Partial source, pre-reduce inside
+    # the timed loop so the reduce cost is counted.
     def _baseline_iter():
         if source_dist_tensors:
             src_dt = source_dist_tensors[0]
@@ -276,94 +189,43 @@ def benchmark_single_shape(
     for _ in range(warmup_iter):
         bc_result = _baseline_iter()
 
-    # Verify correctness for first tensor (M2M modifies target tensors in-place).
+    # Correctness: the sweep wrote target tensors in-place (every bucket_size
+    # produces the same result); compare the first tensor against the baseline.
     if target_local_tensors and target_local_tensors[0] is not None and bc_result is not None:
         if not torch.allclose(target_local_tensors[0], bc_result.to_local()):
-            print(f"[Rank {rank}] M2M result shape: {target_local_tensors[0].shape}")
-            print(f"[Rank {rank}] Baseline result shape: {bc_result.to_local().shape}")
             print(f"[Rank {rank}] Max diff: {(target_local_tensors[0] - bc_result.to_local()).abs().max().item()}")
-            print(f"[Rank {rank}] M2M sample: {target_local_tensors[0]}")
-            print(f"[Rank {rank}] Baseline sample: {bc_result.to_local()}")
             raise ValueError("M2M and Gather-Broadcast results mismatch!")
 
     if device == "cuda":
         torch.cuda.synchronize()
     dist.barrier()
 
-    # Gather-Broadcast method with profiling if enabled
-    if should_profile:
-        # Setup profiling for Gather-Broadcast
-        gb_profiling_spec = ProfilingSpec(
-            enable_profiling=True,
-            dump_folder=UPath(profiling_config["dump_folder"]),
-            save_traces_folder=UPath(f"traces/{mesh_info}/shape_{shape[0]}/rank_{rank}/gather_broadcast_comm"),
-            profile_freq=profiling_config["profile_freq"],
-            warmup_steps=profiling_config["warmup_steps"],
-            active_steps=profiling_config["active_steps"],
-            enable_memory_snapshot=profiling_config["enable_memory_snapshot"],
-        )
-
-        with maybe_enable_profiling(gb_profiling_spec, global_step=0) as profiler:
-            if profiler is not None:
-                # Profiled iterations
-                for step in range(gb_profiling_spec.profile_freq):
-                    profiler.step()
-                    for _ in range(10):
-                        _baseline_iter()
-
-                    # Additional memory snapshot if requested
-                    if gb_profiling_spec.enable_memory_snapshot and step == gb_profiling_spec.warmup_steps + 1:
-                        snapshot_dir = (
-                            f"{gb_profiling_spec.dump_folder}/memory_snapshots/{mesh_info}/shape_{shape[0]}/rank_{rank}"
-                        )
-                        dump_memory_snapshot(snapshot_dir, step + 1000, rank)  # +1000 to distinguish from M2M
-            else:
-                pass
-
-    # Time measurement with CUDA events
-    if device == "cuda":
-        torch.cuda.synchronize()
-    dist.barrier()
-
     start_event = torch.cuda.Event(enable_timing=True)
     end_event = torch.cuda.Event(enable_timing=True)
-
     start_event.record()
     for _ in range(profile_iter):
         _baseline_iter()
     end_event.record()
-
     torch.cuda.synchronize()
     baseline_time = start_event.elapsed_time(end_event) / 1000.0 / profile_iter  # ms -> s
 
     if rank == 0:
-        # Calculate ideal bytes that target ranks need to receive (for all tensors in batch)
         ideal_transfer_bytes = calculate_transfer_bytes(current_target_mesh, target_specs, total_tensor_size_bytes)
         ideal_transfer_gb = ideal_transfer_bytes / (1024**3)
-
-        # Calculate ideal bandwidth (hardware topology aware)
         ideal_bw = calculate_ideal_bandwidth(
-            current_source_mesh,
-            current_target_mesh,
-            target_specs,
-            total_tensor_size_bytes,
-            gpus_per_node,
+            current_source_mesh, current_target_mesh, target_specs, total_tensor_size_bytes, gpus_per_node
         )
 
-        # Effective throughput: how fast we complete the redistribution task
-        # M2M: tests all tensors in batch
-        m2m_effective_throughput = ideal_transfer_gb / m2m_time
-        bucket_effective_throughput = ideal_transfer_gb / bucket_time
-
-        # Baseline: only tests 1 tensor, so divide by num_tensors
+        sweep_tput = {bs: ideal_transfer_gb / t for bs, t in sweep_time.items()}
         single_tensor_ideal_transfer_gb = ideal_transfer_gb / num_tensors
         baseline_effective_throughput = single_tensor_ideal_transfer_gb / baseline_time
 
         print(f"    Batch: {num_tensors} tensors x {shape} = {total_tensor_size_bytes / (1024**2):.2f} MB total")
         print(f"    Ideal M2M transfer (target needs): {ideal_transfer_bytes / (1024**2):.2f} MB")
         print(f"    Ideal bandwidth (RDMA+NVLink): {ideal_bw:.2f} GB/s")
-        print(f"    M2M batch effective throughput ({num_tensors} tensors): {m2m_effective_throughput:.2f} GB/s")
-        print(f"    Bucket batch effective throughput ({num_tensors} tensors): {bucket_effective_throughput:.2f} GB/s")
+        for bs in bucket_sizes:
+            label = "chunk" if bs == 1 else f"{bs // (1024 * 1024)}MB"
+            print(f"    bucket_size={label:>6}: {sweep_tput[bs]:.2f} GB/s")
         print(f"    Baseline effective throughput (1 tensor): {baseline_effective_throughput:.2f} GB/s")
 
         return {
@@ -372,8 +234,9 @@ def benchmark_single_shape(
             "tensor_size_mb": total_tensor_size_bytes / (1024**2),
             "ideal_transfer_mb": ideal_transfer_bytes / (1024**2),
             "ideal_bandwidth_gb_s": ideal_bw,
-            "m2m_effective_throughput_gb_s": m2m_effective_throughput,
-            "bucket_effective_throughput_gb_s": bucket_effective_throughput,
+            "sweep_throughput_gb_s": {str(bs): v for bs, v in sweep_tput.items()},
+            "m2m_effective_throughput_gb_s": sweep_tput[bucket_sizes[0]],
+            "bucket_effective_throughput_gb_s": sweep_tput[bucket_sizes[-1]],
             "baseline_effective_throughput_gb_s": baseline_effective_throughput,
         }
 
@@ -715,19 +578,11 @@ def main():
                     )
                     all_chunks.extend(chunks)
 
-                all_buckets = chunk_to_bucket_ops(
-                    chunks=all_chunks,
-                    bucket_size=BUCKET_SIZE_BYTES,
-                )
-
                 ir_gen_time = (time.perf_counter() - start_time) / profile_iter
                 if rank == 0:
                     print(f"    IR generation time: {ir_gen_time:.6f}s")
                     print(
                         f"    Generated {len(all_chunks)} chunks total ({len(all_chunks) // num_tensors_per_batch} per tensor)"
-                    )
-                    print(
-                        f"    Generated {len(all_buckets)} buckets total ({len(all_buckets) // num_tensors_per_batch} per tensor)"
                     )
                     print(f"    routes: {m2m.routes}")
 
@@ -743,7 +598,6 @@ def main():
                     num_tensors_per_batch,
                     shape,
                     all_chunks,
-                    all_buckets,
                     current_source_mesh,
                     current_target_mesh,
                     source_specs,
@@ -755,6 +609,7 @@ def main():
                     warmup_iter,
                     profile_iter,
                     gpus_per_node,
+                    BUCKET_SIZE_SWEEP,
                     profiling_config,
                     mesh_info,
                     has_partial=has_partial,
@@ -764,7 +619,7 @@ def main():
                     current_results.append(result)
 
                 # Clean up tensors after each shape benchmark
-                del origin_tensors, source_dist_tensors, target_local_tensors, all_chunks, all_buckets
+                del origin_tensors, source_dist_tensors, target_local_tensors, all_chunks
                 if device == "cuda":
                     torch.cuda.empty_cache()
 

--- a/src/etha/comm/get_buckets.py
+++ b/src/etha/comm/get_buckets.py
@@ -16,14 +16,15 @@ def chunk_to_bucket_ops(
     """Bundle same-route chunks (shared ``bucket_key``) up to ``bucket_size`` bytes.
 
     A chunk at least ``bucket_size`` becomes its own bucket; ``bucket_size=1``
-    therefore gives one chunk per bucket (no coalescing).
+    therefore gives one chunk per bucket (no coalescing). A ``no_coalesce`` chunk
+    (Partial transfer) also stays single-entry — see ``Chunk.no_coalesce``.
     """
     buckets: list[Bucket] = []
     grouped_state: dict[tuple, tuple[list[Chunk], int]] = defaultdict(lambda: ([], 0))
 
     for chunk in chunks:
         chunk_bytes = chunk.nbytes
-        if chunk_bytes >= bucket_size:
+        if chunk_bytes >= bucket_size or chunk.no_coalesce:
             buckets.append(_make_bucket([chunk]))
             continue
 

--- a/src/etha/comm/get_chunks.py
+++ b/src/etha/comm/get_chunks.py
@@ -33,6 +33,9 @@ def m2m_to_chunks(
         return []
     source_num_slicers = m2m.source_num_slicers
     target_num_slicers = m2m.target_num_slicers
+    # Partial transfers must not coalesce; set on both ends (this is M2MMap-level, so
+    # source and target ranks agree, keeping send/recv bucketing symmetric).
+    no_coalesce = bool(m2m.source_partial_reductions)
     source_tensor_shape = source_tensor.shape if source_tensor is not None else None
     target_tensor_shape = target_tensor.shape if target_tensor is not None else None
     source_slicer_tuples = None
@@ -80,6 +83,7 @@ def m2m_to_chunks(
                     tensor=source_tensor,
                     transfer_dtype=transfer_dtype,
                     source_partial_groups=source_partial_groups,
+                    no_coalesce=no_coalesce,
                 )
             )
         for dst in route.dsts:
@@ -107,6 +111,7 @@ def m2m_to_chunks(
                         src_slice=src_slice_tuples,
                         dst_slice=dst_slice_tuples,
                         tensor=target_tensor,
+                        no_coalesce=no_coalesce,
                     )
                 )
             else:
@@ -123,6 +128,7 @@ def m2m_to_chunks(
                         dst_slice=dst_slice_tuples,
                         tensor=target_tensor,
                         transfer_dtype=transfer_dtype,
+                        no_coalesce=no_coalesce,
                     )
                 )
     return chunks

--- a/src/etha/comm/ir.py
+++ b/src/etha/comm/ir.py
@@ -82,6 +82,11 @@ class Chunk:
     # reaches the collective; reduce-only (NONE transport) chunks participate
     # without shipping.
     source_partial_groups: list[tuple[dist.ProcessGroup, str]] | None = field(default=None)
+    # Set for every chunk of a Partial transfer (both send and recv ends, keyed off
+    # the M2MMap so it's symmetric). Partial chunks must not coalesce: their per-cell
+    # all_reduce must stay aligned across the reduce group, and a sender-only signal
+    # would desync send/recv bucketing. See chunk_to_bucket_ops.
+    no_coalesce: bool = False
     buffer: torch.Tensor | None = None
 
     def __post_init__(self) -> None:

--- a/src/etha/tensor_bus/agent.py
+++ b/src/etha/tensor_bus/agent.py
@@ -42,6 +42,12 @@ logger = logging.getLogger(__name__)
 
 TIME_INTERVAL = 0.001  # 1ms
 
+# Default coalescing threshold when the client doesn't specify one. 8MB coalesces
+# the many small non-Partial chunks (a clear win on small tensors, never worse than
+# per-chunk on large) while Partial chunks self-exclude via Chunk.no_coalesce. See
+# bench/BUCKET_TUNING.md.
+DEFAULT_COALESCE_BYTES = 8 * 1024 * 1024
+
 
 def _create_partial_groups(
     mesh_tensor: torch.Tensor,
@@ -670,10 +676,11 @@ class TensorBusAgent:
 
             logger.info(f"Agent {self.rank}: Batch {batch_id}: Completed registration for pair '{pair_name}'")
 
-        # Bucketize (cross-pair, by channel key) into BatchState. bucket_size
-        # unset means no coalescing: every chunk becomes its own single-entry
-        # bucket. Chunks are only an intermediate; only buckets are executed.
-        coalesce_bytes = bucket_size or 1
+        # Bucketize (cross-pair, by channel key) into BatchState. Chunks are only an
+        # intermediate; only buckets are executed. Partial chunks self-exclude from
+        # coalescing (Chunk.no_coalesce); everything else coalesces up to the bytes
+        # threshold.
+        coalesce_bytes = bucket_size or DEFAULT_COALESCE_BYTES
         batch_state.send_buckets = chunk_to_bucket_ops(chunks=all_send_chunks, bucket_size=coalesce_bytes)
         batch_state.recv_buckets = chunk_to_bucket_ops(chunks=all_recv_chunks, bucket_size=coalesce_bytes)
         logger.info(


### PR DESCRIPTION
## What did you do

Makes the **bucket (coalesced) transfer path never lose to per-chunk** across the
benchmark matrix, then turns coalescing on by default.

Investigation (full write-up in `bench/BUCKET_TUNING.md`) found two orthogonal root
causes for why coalescing sometimes lost:
1. **size axis** — a single `bucket_size` is wrong for some tensor size; but
   `chunk_to_bucket_ops` already sends any chunk ≥ `bucket_size` on its own, so a
   moderate 8MB threshold coalesces the small chunks (the win) and leaves large ones
   alone (no loss).
2. **Partial axis** — Partial transfers can NOT coalesce. Their per-cell all_reduce
   must stay aligned across the reduce group, and send/recv must bucketize
   symmetrically. Two attempts failed (documented): a batched all_reduce **deadlocks**
   (reduce-only per-cell vs shipping batched mismatch sizes), and a sender-only
   "don't coalesce Partial" **corrupts** (P2P send/recv buffers desync).

Fix: a `Chunk.no_coalesce` flag set from `M2MMap.source_partial_reductions` — the
same map on source and target ranks, so both ends agree and bucketize symmetrically.
Partial chunks stay single-entry (per-cell all_reduce, aligned) = their empirical
optimum; everything else coalesces up to the threshold. Agent default `bucket_size`
1 → 8MB (`DEFAULT_COALESCE_BYTES`).

`bench/transfer_benchmark.py` gains a `bucket_size` sweep to measure this.

## New test cases

No new feature/bug; this is a perf + safety change. The Partial-coalescing hazards
are now structurally excluded (`no_coalesce`). Covered by the 3-layer verification.

## Test results

- CPU unit tests: ✅ 55 passed
- vLLM weight-sync end-to-end: ✅ 3/3 rounds, no agent errors (production Partial MoE on the new 8MB default)
- 16-GPU transfer sweep: ✅ completed clean, **no deadlock, no mismatch**; bucket ≥ chunk everywhere (non-Partial wins up to 3x on small tensors; Partial == chunk, its optimum). 8MB only "loses" on 14/215 partial_dp cases ≤1.11x, which is measurement noise (Partial runs the same single-entry buckets at every bucket_size).

## Other comments

Full milestone log of the investigation (including the two reverted dead ends) is in
`bench/BUCKET_TUNING.md`.